### PR TITLE
ci: add GitHub Actions (lint + test) and adopt ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install "ruff>=0.6"
+      - run: ruff check .
+      - run: ruff format --check .
+
   test:
     name: test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Test (offline)
+        run: pytest -m "not network" -q

--- a/examples/01_mcp_baseline.py
+++ b/examples/01_mcp_baseline.py
@@ -19,16 +19,13 @@ import asyncio
 import json
 
 import mcp.types as types
-from mcp.server.lowlevel import Server
-from mcp.shared.memory import create_connected_server_and_client_session as connect
-
 from _pump import (
     DEVICE_TOKEN,
     PumpDevice,
     start_device,
 )
-
-from thingctx import HttpInvoker, LocalInvoker, MqttInvoker, ThingClient
+from mcp.server.lowlevel import Server
+from mcp.shared.memory import create_connected_server_and_client_session as connect
 
 
 def build_server(pump: PumpDevice, http_url: str, mqtt_addr: str) -> Server:
@@ -40,11 +37,12 @@ def build_server(pump: PumpDevice, http_url: str, mqtt_addr: str) -> Server:
     import urllib.parse
 
     server: Server = Server("pump")
-    subscribers: set[str] = set()   # resource URIs the client subscribed to
+    subscribers: set[str] = set()  # resource URIs the client subscribed to
     auth = {"Authorization": f"Bearer {DEVICE_TOKEN}"}
 
     async def http_get(path: str):
         import httpx
+
         async with httpx.AsyncClient() as c:
             r = await c.get(f"{http_url}/{path}", headers=auth)
             r.raise_for_status()
@@ -52,6 +50,7 @@ def build_server(pump: PumpDevice, http_url: str, mqtt_addr: str) -> Server:
 
     async def http_post(path: str, body: dict):
         import httpx
+
         async with httpx.AsyncClient() as c:
             r = await c.post(f"{http_url}/{path}", json=body, headers=auth)
             r.raise_for_status()
@@ -59,14 +58,16 @@ def build_server(pump: PumpDevice, http_url: str, mqtt_addr: str) -> Server:
 
     async def mqtt_call(topic: str, body: dict):
         import asyncio as _a
+
         import paho.mqtt.client as mqtt
+
         host, _, port = mqtt_addr.partition(":")
         loop = _a.get_event_loop()
         fut: _a.Future = loop.create_future()
         cli = mqtt.Client()
         cli.on_message = lambda c, u, m: (
-            fut.done() or loop.call_soon_threadsafe(
-                fut.set_result, json.loads(m.payload.decode())))
+            fut.done() or loop.call_soon_threadsafe(fut.set_result, json.loads(m.payload.decode()))
+        )
         cli.connect(host, int(port))
         cli.subscribe(f"{topic}/reply")
         cli.loop_start()
@@ -77,37 +78,55 @@ def build_server(pump: PumpDevice, http_url: str, mqtt_addr: str) -> Server:
             cli.loop_stop()
             cli.disconnect()
 
-    #  tools: commands + the property WORKAROUND (a get/set pair) 
+    #  tools: commands + the property WORKAROUND (a get/set pair)
     @server.list_tools()
     async def list_tools():
         obj = {"type": "object"}
         return [
-            types.Tool(name="set_speed", description="Set rpm.",
-                       inputSchema={"type": "object",
-                                    "properties": {"rpm": {"type": "integer"}},
-                                    "required": ["rpm"]}),
+            types.Tool(
+                name="set_speed",
+                description="Set rpm.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"rpm": {"type": "integer"}},
+                    "required": ["rpm"],
+                },
+            ),
             types.Tool(name="estop", description="Emergency stop.", inputSchema=obj),
-            types.Tool(name="read_sensor", description="Read a sensor by id.",
-                       inputSchema={"type": "object",
-                                    "properties": {"id": {"type": "string"}},
-                                    "required": ["id"]}),
+            types.Tool(
+                name="read_sensor",
+                description="Read a sensor by id.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}},
+                    "required": ["id"],
+                },
+            ),
             # the pump's mqtt action -> just another tool here. COST: the
             # server PROXIES it; MCP can't say "this tool is over MQTT".
-            types.Tool(name="set_coolant", description="Open/close coolant.",
-                       inputSchema={"type": "object",
-                                    "properties": {"open": {"type": "boolean"}}}),
+            types.Tool(
+                name="set_coolant",
+                description="Open/close coolant.",
+                inputSchema={"type": "object", "properties": {"open": {"type": "boolean"}}},
+            ),
             # WRITABLE PROPERTY -> a get/set tool pair (the workaround).
-            types.Tool(name="get_target_rpm", description="Read setpoint.",
-                       inputSchema=obj),
-            types.Tool(name="set_target_rpm", description="Write setpoint.",
-                       inputSchema={"type": "object",
-                                    "properties": {"value": {"type": "integer"}},
-                                    "required": ["value"]}),
+            types.Tool(name="get_target_rpm", description="Read setpoint.", inputSchema=obj),
+            types.Tool(
+                name="set_target_rpm",
+                description="Write setpoint.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"value": {"type": "integer"}},
+                    "required": ["value"],
+                },
+            ),
             # device-side trigger so the demo can make the server emit a
             # resources/updated notification (the telemetry push).
-            types.Tool(name="trigger_overheat", description="(demo) heat up.",
-                       inputSchema={"type": "object",
-                                    "properties": {"temp": {"type": "integer"}}}),
+            types.Tool(
+                name="trigger_overheat",
+                description="(demo) heat up.",
+                inputSchema={"type": "object", "properties": {"temp": {"type": "integer"}}},
+            ),
         ]
 
     @server.call_tool()
@@ -119,12 +138,12 @@ def build_server(pump: PumpDevice, http_url: str, mqtt_addr: str) -> Server:
             return [types.TextContent(type="text", text='{"notified": true}')]
         # Each tool: the author picks the transport and wires it by hand.
         if name == "read_sensor":
-            sid = urllib.parse.quote(str(args["id"]), safe="")   # path templating
-            result = await http_get(f"sensors/{sid}")            # HTTP + bearer
+            sid = urllib.parse.quote(str(args["id"]), safe="")  # path templating
+            result = await http_get(f"sensors/{sid}")  # HTTP + bearer
         elif name == "set_coolant":
-            result = await mqtt_call("pump/set_coolant", args)   # MQTT round trip
+            result = await mqtt_call("pump/set_coolant", args)  # MQTT round trip
         elif name == "set_speed":
-            result = pump.set_speed(args["rpm"])                 # local
+            result = pump.set_speed(args["rpm"])  # local
         elif name == "estop":
             result = pump.estop()
         elif name == "get_target_rpm":
@@ -135,31 +154,33 @@ def build_server(pump: PumpDevice, http_url: str, mqtt_addr: str) -> Server:
             raise ValueError(f"unknown tool {name}")
         return [types.TextContent(type="text", text=json.dumps(result))]
 
-    #  resources: state read + the EVENT workaround (a polled resource) 
+    #  resources: state read + the EVENT workaround (a polled resource)
     @server.list_resources()
     async def list_resources():
         return [
-            types.Resource(uri="pump://status", name="status",
-                           description="Pump status."),
-            types.Resource(uri="pump://overheat/latest", name="overheat",
-                           description="Latest overheat reading (poll)."),
+            types.Resource(uri="pump://status", name="status", description="Pump status."),
+            types.Resource(
+                uri="pump://overheat/latest",
+                name="overheat",
+                description="Latest overheat reading (poll).",
+            ),
         ]
 
     @server.read_resource()
     async def read_resource(uri):
         u = str(uri)
         if u == "pump://status":
-            return json.dumps(await http_get("status"))   # HTTP + bearer
+            return json.dumps(await http_get("status"))  # HTTP + bearer
         if u == "pump://overheat/latest":
             return json.dumps({"temp": pump.temp, "limit": 80})
         raise ValueError(f"unknown resource {u}")
 
-    #  resources/subscribe: MCP's real push (notify a changed URI) 
+    #  resources/subscribe: MCP's real push (notify a changed URI)
     @server.subscribe_resource()
     async def subscribe_resource(uri):
         subscribers.add(str(uri))
 
-    #  a prompt (WoT has no equivalent) 
+    #  a prompt (WoT has no equivalent)
     @server.list_prompts()
     async def list_prompts():
         return [types.Prompt(name="diagnose", description="Diagnose the pump.")]
@@ -168,14 +189,17 @@ def build_server(pump: PumpDevice, http_url: str, mqtt_addr: str) -> Server:
     async def get_prompt(name: str, args):
         return types.GetPromptResult(
             description="Diagnose the pump.",
-            messages=[types.PromptMessage(
-                role="user",
-                content=types.TextContent(
-                    type="text",
-                    text="Read pump://status and report if the pump is healthy."))],
+            messages=[
+                types.PromptMessage(
+                    role="user",
+                    content=types.TextContent(
+                        type="text", text="Read pump://status and report if the pump is healthy."
+                    ),
+                )
+            ],
         )
 
-    server._pump_subscribers = subscribers   # exposed so we can notify
+    server._pump_subscribers = subscribers  # exposed so we can notify
     return server
 
 
@@ -208,30 +232,51 @@ async def main() -> None:
 
             async def call(name, args=None):
                 r = await session.call_tool(name, args or {})
-                return "".join(c.text for c in r.content
-                               if getattr(c, "type", "") == "text").strip()
+                return "".join(
+                    c.text for c in r.content if getattr(c, "type", "") == "text"
+                ).strip()
 
             async def read(uri):
                 r = await session.read_resource(uri)
                 return r.contents[0].text
 
-            check("COMMAND   set_speed(900)",
-                  await call("set_speed", {"rpm": 900}), oracle.set_speed(900))
-            check("COMMAND   estop()",
-                  await call("estop"), oracle.estop())
-            check("PATH-READ read_sensor('temp-1')   [hand-wired HTTP + path]",
-                  await call("read_sensor", {"id": "temp-1"}), oracle.read_sensor("temp-1"))
-            check("WRITE     set_target_rpm(1500)     [a tool pair]",
-                  await call("set_target_rpm", {"value": 1500}), oracle.set_target_rpm(1500))
-            check("READ      get_target_rpm()",
-                  await call("get_target_rpm"), {"target_rpm": oracle.get_target_rpm()})
-            check("MQTT-ACT  set_coolant(open=True)     [hand-wired MQTT round trip]",
-                  await call("set_coolant", {"open": True}), oracle.set_coolant(True))
+            check(
+                "COMMAND   set_speed(900)",
+                await call("set_speed", {"rpm": 900}),
+                oracle.set_speed(900),
+            )
+            check("COMMAND   estop()", await call("estop"), oracle.estop())
+            check(
+                "PATH-READ read_sensor('temp-1')   [hand-wired HTTP + path]",
+                await call("read_sensor", {"id": "temp-1"}),
+                oracle.read_sensor("temp-1"),
+            )
+            check(
+                "WRITE     set_target_rpm(1500)     [a tool pair]",
+                await call("set_target_rpm", {"value": 1500}),
+                oracle.set_target_rpm(1500),
+            )
+            check(
+                "READ      get_target_rpm()",
+                await call("get_target_rpm"),
+                {"target_rpm": oracle.get_target_rpm()},
+            )
+            check(
+                "MQTT-ACT  set_coolant(open=True)     [hand-wired MQTT round trip]",
+                await call("set_coolant", {"open": True}),
+                oracle.set_coolant(True),
+            )
 
-            check("STATE     read pump://status        [hand-wired HTTP]",
-                  await read("pump://status"), oracle.status())
-            check("EVENT     read overheat/latest",
-                  await read("pump://overheat/latest"), {"temp": oracle.temp, "limit": 80})
+            check(
+                "STATE     read pump://status        [hand-wired HTTP]",
+                await read("pump://status"),
+                oracle.status(),
+            )
+            check(
+                "EVENT     read overheat/latest",
+                await read("pump://overheat/latest"),
+                {"temp": oracle.temp, "limit": 80},
+            )
 
             prompt = await session.get_prompt("diagnose", {})
             text = prompt.messages[0].content.text
@@ -247,8 +292,11 @@ async def main() -> None:
             assert notes, "no resources/updated notification arrived"
             uri = notes[-1]
             assert uri == "pump://overheat/latest"
-            check("PUSH      notified->re-read           [URI, not payload]",
-                  await read(uri), {"temp": oracle.temp, "limit": 80})
+            check(
+                "PUSH      notified->re-read           [URI, not payload]",
+                await read(uri),
+                {"temp": oracle.temp, "limit": 80},
+            )
 
         print("\nEvery result reached the pump over the same transports as 02")
         print("(HTTP, MQTT, local), but through the hand-wired MCP server.")

--- a/examples/02_thingctx_baseline.py
+++ b/examples/02_thingctx_baseline.py
@@ -36,9 +36,11 @@ async def main() -> None:
         # mqtt, covering the full surface.
         client = ThingClient(
             tds=[td],
-            invokers=[LocalInvoker(pump),
-                      HttpInvoker(credentials={"bearer_sc": DEVICE_TOKEN}),
-                      MqttInvoker(timeout=5)],
+            invokers=[
+                LocalInvoker(pump),
+                HttpInvoker(credentials={"bearer_sc": DEVICE_TOKEN}),
+                MqttInvoker(timeout=5),
+            ],
             validate=True,
         )
 
@@ -53,34 +55,58 @@ async def main() -> None:
             assert got == expected, f"{label}: thingctx {got!r}, device {expected!r}"
             print(f"{label:<34}-> {got}  ok == device")
 
-        check("COMMAND    set_speed(900)",
-              await client.invoke("pump.set_speed", {"rpm": 900}), oracle.set_speed(900))
-        check("COMMAND    estop()",
-              await client.invoke("pump.estop"), oracle.estop())
-        check("PATH-READ  read_sensor('temp-1')   [uriVar {id}, no hand-coded REST]",
-              await client.invoke("pump.read_sensor", {"id": "temp-1"}), oracle.read_sensor("temp-1"))
-        check("WRITE      target_rpm <- 1500       [a typed property, not a pair]",
-              await client.write_property("pump.target_rpm", 1500), oracle.set_target_rpm(1500))
-        check("READ       target_rpm",
-              await client.read_property("pump.target_rpm"), oracle.get_target_rpm())
-        check("READ-ONLY  rpm write rejected",
-              await client.write_property("pump.rpm", 5), {"error": "property pump.rpm is read-only"})
-        check("STATE      status()",
-              await client.invoke("pump.status"), oracle.status())
+        check(
+            "COMMAND    set_speed(900)",
+            await client.invoke("pump.set_speed", {"rpm": 900}),
+            oracle.set_speed(900),
+        )
+        check("COMMAND    estop()", await client.invoke("pump.estop"), oracle.estop())
+        check(
+            "PATH-READ  read_sensor('temp-1')   [uriVar {id}, no hand-coded REST]",
+            await client.invoke("pump.read_sensor", {"id": "temp-1"}),
+            oracle.read_sensor("temp-1"),
+        )
+        check(
+            "WRITE      target_rpm <- 1500       [a typed property, not a pair]",
+            await client.write_property("pump.target_rpm", 1500),
+            oracle.set_target_rpm(1500),
+        )
+        check(
+            "READ       target_rpm",
+            await client.read_property("pump.target_rpm"),
+            oracle.get_target_rpm(),
+        )
+        check(
+            "READ-ONLY  rpm write rejected",
+            await client.write_property("pump.rpm", 5),
+            {"error": "property pump.rpm is read-only"},
+        )
+        check("STATE      status()", await client.invoke("pump.status"), oracle.status())
         # MQTT, set_coolant routes over a real broker (the form is mqtt://)
-        check("MQTT       set_coolant(open=True)    [routed over real MQTT]",
-              await client.invoke("pump.set_coolant", {"open": True}), oracle.set_coolant(True))
+        check(
+            "MQTT       set_coolant(open=True)    [routed over real MQTT]",
+            await client.invoke("pump.set_coolant", {"open": True}),
+            oracle.set_coolant(True),
+        )
 
         # PROMPT, the WoT-native equivalent of MCP's get_prompt, via the
         # tc:PromptTemplate extension. The template lives in the TD, so it
         # expands CLIENT-SIDE, no device call (the device has no diagnose
         # method). The TD is self-sufficient.
         from thingctx.extensions.prompts import get_prompt
+
         msgs = await get_prompt(client, "pump.diagnose", {"severity": "high"})
-        check("PROMPT     get_prompt(diagnose)     [tc:template, no device call]",
-              msgs, [{"role": "user", "content":
-                      "Severity high: read the pump status, list any sensor "
-                      "reading over its limit, and say whether the pump is healthy."}])
+        check(
+            "PROMPT     get_prompt(diagnose)     [tc:template, no device call]",
+            msgs,
+            [
+                {
+                    "role": "user",
+                    "content": "Severity high: read the pump status, list any sensor "
+                    "reading over its limit, and say whether the pump is healthy.",
+                }
+            ],
+        )
 
         # EVENT, a real subscription; the typed payload arrives INLINE.
         # Assert the pushed value is the device's event, not a URI.

--- a/examples/03_thingctx_llm.py
+++ b/examples/03_thingctx_llm.py
@@ -37,10 +37,13 @@ async def main() -> None:
         # Same TD + invokers as 02, the full surface. The only new thing
         # is `model=`: the LLM now drives it.
         host = thingctx.from_td(
-            td, model=model,
-            invokers=[LocalInvoker(pump),
-                      HttpInvoker(credentials={"bearer_sc": DEVICE_TOKEN}),
-                      MqttInvoker(timeout=5)],
+            td,
+            model=model,
+            invokers=[
+                LocalInvoker(pump),
+                HttpInvoker(credentials={"bearer_sc": DEVICE_TOKEN}),
+                MqttInvoker(timeout=5),
+            ],
             resilient=True,
         )
         print(f"model: {model}\n")
@@ -53,13 +56,12 @@ async def main() -> None:
 
         # 2) PROMPT, a user picks a declared template; it seeds the agent.
         prompts = list_prompts(host.client)
-        print(f"PROMPTS the Thing declares (tc:PromptTemplate): "
-              f"{[p['name'] for p in prompts]}")
+        print(f"PROMPTS the Thing declares (tc:PromptTemplate): {[p['name'] for p in prompts]}")
         msgs = await get_prompt(host.client, "pump.diagnose", {"severity": "high"})
-        seed = msgs[0]["content"]              # the expanded template text
-        print(f"  get_prompt('pump.diagnose', severity=high) ->")
+        seed = msgs[0]["content"]  # the expanded template text
+        print("  get_prompt('pump.diagnose', severity=high) ->")
         print(f"    {seed!r}")
-        diagnosis = await host.chat(seed)       # feed it to the LLM
+        diagnosis = await host.chat(seed)  # feed it to the LLM
         print(f"  LLM acted on the prompt -> {diagnosis}")
 
         print("\nNo tool-calling written. The model drove the same TD as 02;")

--- a/examples/_pump.py
+++ b/examples/_pump.py
@@ -22,7 +22,7 @@ class PumpDevice:
         self.stopped = False
         self.coolant_open = False
         self._sensors = {"temp-1": 72, "vibration": 3}
-        self._listeners: list = []   # local invokers subscribed for pushes
+        self._listeners: list = []  # local invokers subscribed for pushes
         self._sse_queues: list = []  # HTTP/SSE client queues (over the wire)
 
     # actions
@@ -38,10 +38,10 @@ class PumpDevice:
         self.rpm = 0
         return {"stopped": True, "reason": reason}
 
-    def read_sensor(self, id: str) -> dict:           # uriVariable: {id}
+    def read_sensor(self, id: str) -> dict:  # uriVariable: {id}
         return {"id": id, "value": self._sensors.get(id, 0)}
 
-    def set_coolant(self, open: bool) -> dict:        # the mqtt action
+    def set_coolant(self, open: bool) -> dict:  # the mqtt action
         self.coolant_open = open
         return {"ok": True, "coolant_open": open}
 
@@ -51,6 +51,7 @@ class PumpDevice:
         import io
 
         from PIL import Image, ImageDraw
+
         over = self.temp > 80
         img = Image.new("RGB", (160, 120), (20, 20, 24))
         d = ImageDraw.Draw(img)
@@ -107,7 +108,7 @@ class PumpDevice:
         return asyncio.ensure_future(_emit_loop())
 
 
-DEVICE_TOKEN = "demo-bearer-token"   # the secret the TD's bearer_sc expects
+DEVICE_TOKEN = "demo-bearer-token"  # the secret the TD's bearer_sc expects
 
 
 def start_http_server(device: PumpDevice):
@@ -194,7 +195,7 @@ def start_device():
     what you write against thingctx."""
     pump = PumpDevice()
     url, server = start_http_server(pump)
-    broker = start_mqtt_broker(pump)              # real mosquitto, or None
+    broker = start_mqtt_broker(pump)  # real mosquitto, or None
     mqtt_addr = f"{broker[0]}:{broker[1]}" if broker else "broker"
     td = pump_td(url, mqtt_addr)
 
@@ -233,9 +234,10 @@ def start_mqtt_broker(device: PumpDevice):
     conf.close()
     proc = subprocess.Popen(
         ["mosquitto", "-c", conf.name],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
-    time.sleep(0.4)   # let the broker come up
+    time.sleep(0.4)  # let the broker come up
 
     # device-side subscriber: receive set_coolant, run it, reply.
     sub = mqtt.Client()
@@ -273,15 +275,15 @@ def pump_td(http_url: str, mqtt_broker: str = "broker") -> dict:
     from pathlib import Path
 
     raw = (Path(__file__).parent / "pump.td.json").read_text()
-    return json.loads(
-        raw.replace("{BASE_URL}", http_url).replace("{MQTT_BROKER}", mqtt_broker)
-    )
+    return json.loads(raw.replace("{BASE_URL}", http_url).replace("{MQTT_BROKER}", mqtt_broker))
 
 
 #  pick a model for each modality, or None if none is reachable
 
+
 def _ollama_models() -> list[str]:
     import urllib.request
+
     try:
         with urllib.request.urlopen("http://localhost:11434/api/tags", timeout=1) as r:
             return [m["name"] for m in json.loads(r.read()).get("models", [])]
@@ -293,6 +295,7 @@ def pick_llm_model() -> str | None:
     """A text LLM litellm can drive: a local Ollama Qwen, else an API key,
     else None."""
     import os
+
     names = [n for n in _ollama_models() if "vl" not in n]
     for want in ("qwen2.5:7b", "qwen3:8b"):
         if want in names:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ validate = ["jsonschema>=4.0"]
 mcp = ["mcp>=1.0"]
 # Everything.
 all = ["litellm>=1.0", "httpx>=0.25", "paho-mqtt>=2.0", "jsonschema>=4.0", "mcp>=1.0"]
-dev = ["pytest>=7", "pytest-asyncio>=0.21", "jsonschema>=4.0", "mcp>=1.0", "httpx>=0.25"]
+dev = ["pytest>=7", "pytest-asyncio>=0.21", "jsonschema>=4.0", "mcp>=1.0", "httpx>=0.25", "ruff>=0.6"]
 
 [project.scripts]
 # Serve a Thing (or a whole fleet of TDs) to any MCP client.
@@ -49,3 +49,11 @@ thingctx = ["data/*.json"]
 markers = ["network: hits the network; deselect with -m 'not network'"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+# pycodestyle errors, pyflakes, import sorting, pyupgrade, bugbear.
+select = ["E", "F", "I", "UP", "B"]

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -15,7 +15,8 @@ For the pure client without an LLM, build a ThingClient directly.
 """
 
 # ThingClient: TD -> tools + invoke/read/write/observe/subscribe. No LLM.
-from thingctx.runtime import ThingClient
+from thingctx.client import from_file, from_td, from_url
+
 # LLMHost: optional tool-calling loop, in thingctx.contrib.
 from thingctx.contrib.llm import LLMHost
 from thingctx.invokers import (
@@ -24,6 +25,14 @@ from thingctx.invokers import (
     LocalInvoker,
     MqttInvoker,
 )
+from thingctx.registry import (
+    FileRegistry,
+    Registry,
+    TDDRegistry,
+    from_arg,
+    from_args,
+)
+from thingctx.runtime import ThingClient
 from thingctx.thing import (
     WoTAction,
     WoTEvent,
@@ -33,15 +42,7 @@ from thingctx.thing import (
     actions_to_tools,
     parse_thing,
 )
-from thingctx.client import from_file, from_td, from_url
 from thingctx.validate import TDValidationError, validate_td
-from thingctx.registry import (
-    FileRegistry,
-    Registry,
-    TDDRegistry,
-    from_args,
-    from_arg,
-)
 
 __version__ = "0.1.0"
 

--- a/src/thingctx/client.py
+++ b/src/thingctx/client.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from thingctx.contrib.llm import LLMHost
 from thingctx.invokers import HttpInvoker, Invoker, LocalInvoker
@@ -26,10 +26,10 @@ def _default_invokers() -> list[Invoker]:
 
 
 def from_td(
-    td: "dict[str, Any] | list[dict[str, Any]]",
+    td: dict[str, Any] | list[dict[str, Any]],
     *,
     model: str = "anthropic/claude-sonnet-4-6",
-    invokers: Optional[list[Invoker]] = None,
+    invokers: list[Invoker] | None = None,
     validate: bool = False,
     **host_kwargs: Any,
 ) -> LLMHost:
@@ -46,10 +46,10 @@ def from_td(
 
 
 def from_file(
-    path: "str | Path",
+    path: str | Path,
     *,
     model: str = "anthropic/claude-sonnet-4-6",
-    invokers: Optional[list[Invoker]] = None,
+    invokers: list[Invoker] | None = None,
     **host_kwargs: Any,
 ) -> LLMHost:
     """From a ``.td.json`` file (one TD or a list of TDs)."""
@@ -61,7 +61,7 @@ async def from_url(
     url: str,
     *,
     model: str = "anthropic/claude-sonnet-4-6",
-    invokers: Optional[list[Invoker]] = None,
+    invokers: list[Invoker] | None = None,
     **host_kwargs: Any,
 ) -> LLMHost:
     """Fetch a live Thing's TD from ``url`` and return a ready host.

--- a/src/thingctx/contrib/__init__.py
+++ b/src/thingctx/contrib/__init__.py
@@ -1,6 +1,6 @@
 """Optional helpers built on ThingClient. Import only what you use.
 
-    from thingctx.contrib import LLMHost   # text tool-calling loop
+from thingctx.contrib import LLMHost   # text tool-calling loop
 """
 
 from thingctx.contrib.llm import LLMHost

--- a/src/thingctx/contrib/llm.py
+++ b/src/thingctx/contrib/llm.py
@@ -9,7 +9,8 @@ lazily here only, so the pure ThingClient has no LLM dependency.
 from __future__ import annotations
 
 import json
-from typing import Any, Awaitable, Callable, Optional
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from thingctx.runtime import ThingClient, to_text
 
@@ -46,9 +47,9 @@ class LLMHost:
         client: ThingClient,
         *,
         model: str = "anthropic/claude-sonnet-4-6",
-        system: Optional[str] = None,
+        system: str | None = None,
         max_rounds: int = 8,
-        chat_fn: Optional[ChatFn] = None,
+        chat_fn: ChatFn | None = None,
         resilient: bool = False,
     ) -> None:
         self._client = client
@@ -83,7 +84,7 @@ class LLMHost:
 
         tools = self._client.list_actions()
         chat = self._chat_fn or self._litellm_chat
-        memo: dict[tuple, str] = {}          # only used when resilient
+        memo: dict[tuple, str] = {}  # only used when resilient
 
         for _ in range(self._max_rounds):
             assistant = await chat(messages, tools)
@@ -102,18 +103,20 @@ class LLMHost:
                 except json.JSONDecodeError:
                     args = {}
                 if self._resilient and (name, raw_args) in memo:
-                    result_text = memo[(name, raw_args)]   # cached; don't re-run
+                    result_text = memo[(name, raw_args)]  # cached; don't re-run
                 else:
                     all_repeats = False
                     result_text = to_text(await self._client.invoke(name, args))
                     if self._resilient:
                         memo[(name, raw_args)] = result_text
-                messages.append({
-                    "role": "tool",
-                    "tool_call_id": call.get("id", name),
-                    "name": name,
-                    "content": result_text,
-                })
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call.get("id", name),
+                        "name": name,
+                        "content": result_text,
+                    }
+                )
 
             # resilient: all calls were repeats, so force a no-tools turn.
             if self._resilient and all_repeats:
@@ -175,7 +178,9 @@ class LLMHost:
         )
 
     async def _litellm_chat(
-        self, messages: list[dict[str, Any]], tools: list[dict[str, Any]],
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
     ) -> dict[str, Any]:
         import asyncio
 

--- a/src/thingctx/extensions/prompts.py
+++ b/src/thingctx/extensions/prompts.py
@@ -32,6 +32,7 @@ def list_prompts(client: Any) -> list[dict[str, Any]]:
     description, arguments}] with arguments from the input schema."""
     out: list[dict[str, Any]] = []
     from thingctx.thing import _tool_name
+
     for thing in client.things:
         for action in thing.actions.values():
             if not action.has_type(TERM):
@@ -39,20 +40,24 @@ def list_prompts(client: Any) -> list[dict[str, Any]]:
             schema = action.input_schema or {}
             props = schema.get("properties", {})
             required = set(schema.get("required", []))
-            out.append({
-                "name": _tool_name(thing.id, action.name),
-                "description": action.description,
-                "arguments": [
-                    {"name": k,
-                     "description": v.get("description", ""),
-                     "required": k in required}
-                    for k, v in props.items()
-                ],
-            })
+            out.append(
+                {
+                    "name": _tool_name(thing.id, action.name),
+                    "description": action.description,
+                    "arguments": [
+                        {
+                            "name": k,
+                            "description": v.get("description", ""),
+                            "required": k in required,
+                        }
+                        for k, v in props.items()
+                    ],
+                }
+            )
     return out
 
 
-async def get_prompt(client: Any, name: str, arguments: "dict[str, Any] | None" = None):
+async def get_prompt(client: Any, name: str, arguments: dict[str, Any] | None = None):
     """Expand a prompt template into [{role, content}] messages. If the
     TD carries tc:template, expand it client-side ({arg} filled from
     arguments); else invoke the action. Raises ValueError if name is not
@@ -67,9 +72,10 @@ async def get_prompt(client: Any, name: str, arguments: "dict[str, Any] | None" 
     return await client.invoke(name, args)
 
 
-def _expand(template: Any, args: "dict[str, Any]") -> list[dict[str, Any]]:
+def _expand(template: Any, args: dict[str, Any]) -> list[dict[str, Any]]:
     """Fill {arg} placeholders. A string becomes one user message; a list
     of {role, content} messages is filled per message."""
+
     def fill(s: str) -> str:
         for k, v in args.items():
             s = s.replace("{" + k + "}", str(v))
@@ -80,8 +86,12 @@ def _expand(template: Any, args: "dict[str, Any]") -> list[dict[str, Any]]:
     out = []
     for msg in template:
         content = msg.get("content", "")
-        out.append({"role": msg.get("role", "user"),
-                    "content": fill(content) if isinstance(content, str) else content})
+        out.append(
+            {
+                "role": msg.get("role", "user"),
+                "content": fill(content) if isinstance(content, str) else content,
+            }
+        )
     return out
 
 

--- a/src/thingctx/integrations/mcp.py
+++ b/src/thingctx/integrations/mcp.py
@@ -21,7 +21,6 @@ In an MCP client config (e.g. Claude CLI .mcp.json):
 
 from __future__ import annotations
 
-import json
 import sys
 from typing import Any
 
@@ -58,12 +57,14 @@ def build_mcp_server(client: ThingClient, *, name: str = "thingctx"):
                 explicit = action.raw.get("tc:mcp") or action.raw.get("mcp") or {}
                 hints.update({k: v for k, v in explicit.items() if k in valid})
                 ann = types.ToolAnnotations(**hints)
-            out.append(types.Tool(
-                name=fn["name"],
-                description=fn.get("description", ""),
-                inputSchema=fn.get("parameters", {"type": "object"}),
-                annotations=ann,
-            ))
+            out.append(
+                types.Tool(
+                    name=fn["name"],
+                    description=fn.get("description", ""),
+                    inputSchema=fn.get("parameters", {"type": "object"}),
+                    annotations=ann,
+                )
+            )
         return out
 
     @server.call_tool()
@@ -79,9 +80,9 @@ def build_mcp_server(client: ThingClient, *, name: str = "thingctx"):
     async def list_resources():
         out = []
         for name in client.list_properties():
-            out.append(types.Resource(
-                uri=_prop_uri(name), name=name,
-                description=f"Property {name}"))
+            out.append(
+                types.Resource(uri=_prop_uri(name), name=name, description=f"Property {name}")
+            )
         return out
 
     @server.read_resource()
@@ -96,25 +97,34 @@ def build_mcp_server(client: ThingClient, *, name: str = "thingctx"):
     async def list_prompts_handler():
         out = []
         for p in list_prompts(client):
-            out.append(types.Prompt(
-                name=p["name"], description=p.get("description", ""),
-                arguments=[
-                    types.PromptArgument(
-                        name=a["name"], description=a.get("description", ""),
-                        required=a.get("required", False))
-                    for a in p.get("arguments", [])
-                ]))
+            out.append(
+                types.Prompt(
+                    name=p["name"],
+                    description=p.get("description", ""),
+                    arguments=[
+                        types.PromptArgument(
+                            name=a["name"],
+                            description=a.get("description", ""),
+                            required=a.get("required", False),
+                        )
+                        for a in p.get("arguments", [])
+                    ],
+                )
+            )
         return out
 
     @server.get_prompt()
     async def get_prompt_handler(name: str, arguments: dict | None):
         messages = await get_prompt(client, name, arguments or {})
-        return types.GetPromptResult(messages=[
-            types.PromptMessage(
-                role=m.get("role", "user"),
-                content=types.TextContent(type="text", text=str(m.get("content", ""))))
-            for m in messages
-        ])
+        return types.GetPromptResult(
+            messages=[
+                types.PromptMessage(
+                    role=m.get("role", "user"),
+                    content=types.TextContent(type="text", text=str(m.get("content", ""))),
+                )
+                for m in messages
+            ]
+        )
 
     return server
 
@@ -124,15 +134,18 @@ def client_from_registry(registry, credentials: dict | None = None) -> ThingClie
     invokers whose deps are installed (local always; http/mqtt if
     importable). `registry` is anything with a fetch() -> list[dict]."""
     from thingctx.invokers import LocalInvoker
+
     tds = registry.fetch()
     invokers: list[Any] = [LocalInvoker()]
     try:
         from thingctx.invokers import HttpInvoker
+
         invokers.append(HttpInvoker(credentials=credentials or {}))
     except Exception:  # noqa: BLE001
         pass
     try:
         from thingctx.invokers import MqttInvoker
+
         invokers.append(MqttInvoker())
     except Exception:  # noqa: BLE001
         pass
@@ -153,11 +166,15 @@ async def serve(registry) -> None:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print("usage: python -m thingctx.integrations.mcp <dir | file | url | tdd:url> ...",
-              file=sys.stderr)
+        print(
+            "usage: python -m thingctx.integrations.mcp <dir | file | url | tdd:url> ...",
+            file=sys.stderr,
+        )
         raise SystemExit(2)
     import asyncio
+
     from thingctx.registry import from_args
+
     asyncio.run(serve(from_args(sys.argv[1:])))
 
 

--- a/src/thingctx/invokers.py
+++ b/src/thingctx/invokers.py
@@ -11,7 +11,8 @@ A new transport is one more Invoker; the TD is unchanged.
 from __future__ import annotations
 
 import json
-from typing import Any, Awaitable, Callable, Optional, Protocol, runtime_checkable
+from collections.abc import Callable
+from typing import Any, Protocol, runtime_checkable
 
 from thingctx.thing import WoTAction, WoTForm
 
@@ -38,9 +39,11 @@ class Invoker(Protocol):
     scheme: str
 
     async def invoke(
-        self, action: WoTAction, form: WoTForm, arguments: dict[str, Any],
-    ) -> Any:
-        ...
+        self,
+        action: WoTAction,
+        form: WoTForm,
+        arguments: dict[str, Any],
+    ) -> Any: ...
 
 
 class LocalInvoker:
@@ -74,7 +77,7 @@ class LocalInvoker:
     def register(self, key: str, fn: Callable[..., Any]) -> None:
         self._fns[key] = fn
 
-    def _resolve(self, name: str) -> "Callable[..., Any] | None":
+    def _resolve(self, name: str) -> Callable[..., Any] | None:
         if name in self._fns:
             return self._fns[name]
         if self._obj is not None:
@@ -90,6 +93,7 @@ class LocalInvoker:
         if fn is None:
             return {"error": f"no local callable registered for {key!r}"}
         import inspect
+
         try:
             result = fn(**arguments)
         except TypeError as e:
@@ -105,10 +109,10 @@ class LocalInvoker:
         """Read a property's current value. Resolves ``get_<name>`` /
         ``<name>`` on the device object, else a same-named attribute."""
         key = (form.href.split("://", 1)[-1] if form.href else "") or prop.name
-        fn = self._resolve(f"get_{prop.name}") or self._resolve(key) \
-            or self._resolve(prop.name)
+        fn = self._resolve(f"get_{prop.name}") or self._resolve(key) or self._resolve(prop.name)
         if fn is not None:
             import inspect
+
             r = fn()
             return await r if inspect.isawaitable(r) else r
         # Fall back to a plain attribute on the device object.
@@ -120,6 +124,7 @@ class LocalInvoker:
         """Write a property: call ``set_<name>(value)`` on the device,
         else set a same-named attribute."""
         import inspect
+
         fn = self._resolve(f"set_{prop.name}")
         if fn is not None:
             r = fn(value)
@@ -171,18 +176,18 @@ class HttpInvoker:
         self,
         *,
         timeout: float = 30.0,
-        headers: Optional[dict] = None,
-        credentials: Optional[dict] = None,
+        headers: dict | None = None,
+        credentials: dict | None = None,
     ) -> None:
         self._timeout = timeout
         self._headers = headers or {}
         self._credentials = credentials or {}
-        self._schemes_by_name: dict = {}   # set by with_security()
+        self._schemes_by_name: dict = {}  # set by with_security()
         self._active: tuple = ()
         # This invoker also claims https.
         self.schemes = ("http", "https")
 
-    def with_security(self, thing) -> "HttpInvoker":
+    def with_security(self, thing) -> HttpInvoker:
         """Bind a parsed Thing's declared security schemes so requests
         carry the right auth. Returns self (chainable)."""
         self._schemes_by_name = dict(getattr(thing, "security_schemes", {}) or {})
@@ -203,6 +208,7 @@ class HttpInvoker:
                 headers["Authorization"] = f"Bearer {secret}"
             elif scheme.scheme == "basic":
                 import base64
+
                 token = base64.b64encode(secret.encode()).decode()
                 headers["Authorization"] = f"Basic {token}"
             elif scheme.scheme == "apikey":
@@ -230,12 +236,17 @@ class HttpInvoker:
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             if method.upper() == "GET":
                 resp = await client.get(
-                    form.href, headers=headers, params={**params, **arguments},
+                    form.href,
+                    headers=headers,
+                    params={**params, **arguments},
                 )
             else:
                 resp = await client.request(
-                    method, form.href, json=arguments,
-                    headers=headers, params=params,
+                    method,
+                    form.href,
+                    json=arguments,
+                    headers=headers,
+                    params=params,
                 )
             resp.raise_for_status()
             return _decode(resp)
@@ -258,7 +269,10 @@ class HttpInvoker:
         headers, params = self._hp()
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             resp = await client.put(
-                form.href, json=value, headers=headers, params=params,
+                form.href,
+                json=value,
+                headers=headers,
+                params=params,
             )
             resp.raise_for_status()
             return _decode(resp, empty={"ok": True})
@@ -298,7 +312,7 @@ class MqttInvoker:
 
     scheme = "mqtt"
 
-    def __init__(self, *, broker: Optional[str] = None, timeout: float = 10.0) -> None:
+    def __init__(self, *, broker: str | None = None, timeout: float = 10.0) -> None:
         self._broker = broker
         self._timeout = timeout
 
@@ -382,8 +396,9 @@ class MqttInvoker:
 
 
 def select_invoker(
-    invokers: list[Invoker], form: WoTForm,
-) -> Optional[Invoker]:
+    invokers: list[Invoker],
+    form: WoTForm,
+) -> Invoker | None:
     """Pick the invoker that handles ``form``'s transport scheme."""
     want = form.scheme
     for inv in invokers:

--- a/src/thingctx/registry.py
+++ b/src/thingctx/registry.py
@@ -39,8 +39,11 @@ class FileRegistry:
         if s.startswith(("http://", "https://")):
             return [_get_json(s, self.timeout)]
         if os.path.isdir(s):
-            files = [os.path.join(s, f) for f in sorted(os.listdir(s))
-                     if f.endswith((".td.json", ".json"))]
+            files = [
+                os.path.join(s, f)
+                for f in sorted(os.listdir(s))
+                if f.endswith((".td.json", ".json"))
+            ]
             return [json.loads(open(f).read()) for f in files]
         return [json.loads(open(s).read())]
 
@@ -58,7 +61,7 @@ class TDDRegistry:
         if not url.endswith("/things"):
             url += "/things"
         data = _get_json(url, self.timeout)
-        if isinstance(data, dict):       # some TDDs wrap the list
+        if isinstance(data, dict):  # some TDDs wrap the list
             data = data.get("members") or data.get("things") or [data]
         return list(data)
 
@@ -93,5 +96,6 @@ def from_args(args: list[str]) -> Registry:
 
 def _get_json(url: str, timeout: float):
     import urllib.request
+
     with urllib.request.urlopen(url, timeout=timeout) as r:
         return json.loads(r.read().decode())

--- a/src/thingctx/runtime.py
+++ b/src/thingctx/runtime.py
@@ -9,7 +9,7 @@ subscribe to events. No LLM.
 from __future__ import annotations
 
 import json
-from typing import Any, Optional
+from typing import Any
 
 from thingctx.invokers import Invoker, select_invoker
 from thingctx.thing import (
@@ -25,7 +25,7 @@ class ThingClient:
     agnostic; no LLM."""
 
     @classmethod
-    def from_registry(cls, registry, *, invokers=None, **kwargs) -> "ThingClient":
+    def from_registry(cls, registry, *, invokers=None, **kwargs) -> ThingClient:
         """Build a client over every TD a registry yields. `registry` is
         anything with fetch() -> list[dict] (see thingctx.registry)."""
         return cls(tds=registry.fetch(), invokers=invokers, **kwargs)
@@ -34,22 +34,22 @@ class ThingClient:
         self,
         *,
         tds: list[dict[str, Any]],
-        invokers: Optional[list[Invoker]] = None,
+        invokers: list[Invoker] | None = None,
         only_idempotent: bool = False,
         validate: bool = False,
     ) -> None:
         # validate=True checks each TD against the W3C TD 1.1 schema and
         # raises TDValidationError on nonconformance (needs [validate]).
-        self._things: list[WoTThing] = [
-            parse_thing(td, validate=validate) for td in tds
-        ]
+        self._things: list[WoTThing] = [parse_thing(td, validate=validate) for td in tds]
         self._invokers = list(invokers or [])
         self._tool_specs, self._route = actions_to_tools(
-            self._things, only_idempotent=only_idempotent,
+            self._things,
+            only_idempotent=only_idempotent,
         )
         # Telemetry name to (Thing, Property/Event) maps, keyed by the
         # same short ``<slug>.<name>`` scheme as actions.
         from thingctx.thing import _tool_name
+
         self._props: dict[str, Any] = {}
         self._events: dict[str, Any] = {}
         for thing in self._things:
@@ -68,8 +68,7 @@ class ThingClient:
 
         # Preferred transport order = the order invokers were given.
         self._prefer = tuple(
-            s for inv in self._invokers
-            for s in (getattr(inv, "schemes", None) or (inv.scheme,))
+            s for inv in self._invokers for s in (getattr(inv, "schemes", None) or (inv.scheme,))
         )
 
     def list_actions(self) -> list[dict[str, Any]]:
@@ -85,14 +84,14 @@ class ThingClient:
     def tool_specs(self) -> list[dict[str, Any]]:
         return self._tool_specs
 
-    def action_for(self, tool_name: str) -> Optional[WoTAction]:
+    def action_for(self, tool_name: str) -> WoTAction | None:
         return self._route.get(tool_name)
 
     @property
     def things(self) -> list[WoTThing]:
         return self._things
 
-    async def invoke(self, tool_name: str, arguments: "dict[str, Any] | None" = None) -> Any:
+    async def invoke(self, tool_name: str, arguments: dict[str, Any] | None = None) -> Any:
         """Invoke one action by routing to the transport its form names.
         ``arguments`` defaults to ``{}`` (for no-input actions)."""
         arguments = arguments or {}
@@ -106,13 +105,13 @@ class ThingClient:
         if invoker is None:
             return {
                 "error": (
-                    f"no invoker for transport {form.scheme!r} "
-                    f"(action {tool_name}); register one"
+                    f"no invoker for transport {form.scheme!r} (action {tool_name}); register one"
                 ),
                 "transport": form.scheme,
             }
         # Resolve uriVariables: {id} fills from args and leaves the body.
         import dataclasses
+
         href, rest = form.fill(arguments or {})
         filled = dataclasses.replace(form, href=href) if href != form.href else form
         return await invoker.invoke(action, filled, rest)
@@ -169,7 +168,8 @@ async def _empty_aiter(err: str):
     if False:  # pragma: no cover, make this an async generator
         yield None
     import warnings
-    warnings.warn(err)
+
+    warnings.warn(err, stacklevel=2)
 
 
 def to_text(value: Any) -> str:

--- a/src/thingctx/thing.py
+++ b/src/thingctx/thing.py
@@ -5,7 +5,7 @@ and their transport bindings. Stdlib only.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlparse
 
 
@@ -15,7 +15,7 @@ class WoTForm:
 
     href: str
     op: tuple[str, ...] = ()
-    content_type: Optional[str] = None
+    content_type: str | None = None
     raw: dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -37,6 +37,7 @@ class WoTForm:
             if key in args:
                 used.add(key)
                 from urllib.parse import quote
+
                 return quote(str(args[key]), safe="")
             return m.group(0)
 
@@ -53,7 +54,7 @@ class WoTAction:
     thing_id: str
     description: str
     input_schema: dict[str, Any]
-    output_schema: Optional[dict[str, Any]]
+    output_schema: dict[str, Any] | None
     idempotent: bool
     forms: tuple[WoTForm, ...]
     # JSON-LD @type annotations (e.g. tc:PromptTemplate). raw keeps the
@@ -91,7 +92,7 @@ class WoTAction:
         non-safe action). Used for MCP destructiveHint."""
         return self.requires_approval() or not self.idempotent
 
-    def primary_form(self, *, prefer: tuple[str, ...] = ()) -> Optional[WoTForm]:
+    def primary_form(self, *, prefer: tuple[str, ...] = ()) -> WoTForm | None:
         """Pick a form by preferred transport scheme order; else the
         first."""
         for scheme in prefer:
@@ -115,7 +116,7 @@ class WoTProperty:
     observable: bool
     forms: tuple[WoTForm, ...]
 
-    def primary_form(self, *, prefer: tuple[str, ...] = ()) -> Optional[WoTForm]:
+    def primary_form(self, *, prefer: tuple[str, ...] = ()) -> WoTForm | None:
         for scheme in prefer:
             for f in self.forms:
                 if f.scheme == scheme:
@@ -130,10 +131,10 @@ class WoTEvent:
     name: str
     thing_id: str
     description: str
-    data_schema: Optional[dict[str, Any]]
+    data_schema: dict[str, Any] | None
     forms: tuple[WoTForm, ...]
 
-    def primary_form(self, *, prefer: tuple[str, ...] = ()) -> Optional[WoTForm]:
+    def primary_form(self, *, prefer: tuple[str, ...] = ()) -> WoTForm | None:
         for scheme in prefer:
             for f in self.forms:
                 if f.scheme == scheme:
@@ -147,9 +148,9 @@ class WoTSecurityScheme:
     the TD."""
 
     name: str
-    scheme: str                       # bearer, basic, apikey, nosec
-    in_: str = "header"               # apikey location: header or query
-    key_name: str = "Authorization"   # header/query name for apikey
+    scheme: str  # bearer, basic, apikey, nosec
+    in_: str = "header"  # apikey location: header or query
+    key_name: str = "Authorization"  # header/query name for apikey
 
 
 @dataclass
@@ -160,11 +161,11 @@ class WoTThing:
     title: str
     description: str
     actions: dict[str, WoTAction]
-    properties: dict[str, "WoTProperty"] = field(default_factory=dict)
-    events: dict[str, "WoTEvent"] = field(default_factory=dict)
-    security: tuple[str, ...] = ()                          # active scheme names
-    security_schemes: dict[str, "WoTSecurityScheme"] = field(default_factory=dict)
-    base: Optional[str] = None
+    properties: dict[str, WoTProperty] = field(default_factory=dict)
+    events: dict[str, WoTEvent] = field(default_factory=dict)
+    security: tuple[str, ...] = ()  # active scheme names
+    security_schemes: dict[str, WoTSecurityScheme] = field(default_factory=dict)
+    base: str | None = None
     uri_variables: dict[str, Any] = field(default_factory=dict)
 
 
@@ -176,10 +177,11 @@ def parse_thing(td: dict[str, Any], *, validate: bool = False) -> WoTThing:
     """
     if validate:
         from thingctx.validate import assert_valid_td
+
         assert_valid_td(td)
     thing_id = td.get("id") or td.get("@id") or td.get("title", "thing")
     title = td.get("title", thing_id)
-    base = td.get("base")          # relative form hrefs resolve against this
+    base = td.get("base")  # relative form hrefs resolve against this
     thing_uri_vars = td.get("uriVariables") or {}
     actions: dict[str, WoTAction] = {}
     for name, adef in (td.get("actions") or {}).items():
@@ -188,9 +190,7 @@ def parse_thing(td: dict[str, Any], *, validate: bool = False) -> WoTThing:
         actions[name] = WoTAction(
             name=name,
             thing_id=thing_id,
-            description=(
-                adef.get("description") or adef.get("title") or name
-            ),
+            description=(adef.get("description") or adef.get("title") or name),
             input_schema=adef.get("input") or {"type": "object"},
             output_schema=adef.get("output"),
             idempotent=bool(adef.get("idempotent") or adef.get("safe")),
@@ -252,14 +252,15 @@ def parse_thing(td: dict[str, Any], *, validate: bool = False) -> WoTThing:
 
 
 def _parse_forms(
-    defn: dict[str, Any], *, base: "str | None" = None,
+    defn: dict[str, Any],
+    *,
+    base: str | None = None,
 ) -> tuple[WoTForm, ...]:
     return tuple(
         WoTForm(
             href=_resolve_href(f.get("href", ""), base),
             op=tuple(
-                f["op"] if isinstance(f.get("op"), list)
-                else ([f["op"]] if f.get("op") else [])
+                f["op"] if isinstance(f.get("op"), list) else ([f["op"]] if f.get("op") else [])
             ),
             content_type=f.get("contentType"),
             raw=f,
@@ -275,19 +276,20 @@ def _as_tuple(v: Any) -> tuple[str, ...]:
     return (str(v),) if v else ()
 
 
-def _resolve_href(href: str, base: "str | None") -> str:
+def _resolve_href(href: str, base: str | None) -> str:
     """Resolve a relative href against base; absolute hrefs pass through."""
     if not href or not base:
         return href
     if urlparse(href).scheme:
         return href
     from urllib.parse import urljoin
+
     return urljoin(base if base.endswith("/") else base + "/", href.lstrip("/"))
 
 
 def _all_ops(defn: dict[str, Any]) -> set[str]:
     ops: set[str] = set()
-    for f in (defn.get("forms") or []):
+    for f in defn.get("forms") or []:
         op = f.get("op")
         if isinstance(op, list):
             ops.update(op)
@@ -298,8 +300,7 @@ def _all_ops(defn: dict[str, Any]) -> set[str]:
 
 def _value_schema(pdef: dict[str, Any]) -> dict[str, Any]:
     # The property def minus housekeeping keys is its value schema.
-    drop = {"forms", "observable", "writeOnly", "readOnly", "title",
-            "description", "@type", "op"}
+    drop = {"forms", "observable", "writeOnly", "readOnly", "title", "description", "@type", "op"}
     schema = {k: v for k, v in pdef.items() if k not in drop}
     return schema or {"type": "string"}
 
@@ -338,13 +339,15 @@ def actions_to_tools(
             # output schema into the description.
             if action.output_schema:
                 desc = f"{desc}\nReturns: {_json.dumps(action.output_schema)}"
-            specs.append({
-                "type": "function",
-                "function": {
-                    "name": name,
-                    "description": desc,
-                    "parameters": action.input_schema or {"type": "object"},
-                },
-            })
+            specs.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "description": desc,
+                        "parameters": action.input_schema or {"type": "object"},
+                    },
+                }
+            )
             route[name] = action
     return specs, route

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,22 +9,27 @@ from thingctx import LocalInvoker, ThingClient
 
 TD = {
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
-    "id": "urn:demo:pump:v1", "title": "Pump",
-    "securityDefinitions": {"nosec_sc": {"scheme": "nosec"}}, "security": ["nosec_sc"],
-    "properties": {"rpm": {"type": "integer", "readOnly": True,
-                           "forms": [{"href": "local://rpm"}]},
-                   "target_rpm": {"type": "integer",
-                                  "forms": [{"href": "local://target_rpm"}]}},
-    "actions": {"set_speed": {"input": {"type": "object",
-                              "properties": {"rpm": {"type": "integer"}}},
-                              "forms": [{"href": "local://set_speed"}]}},
+    "id": "urn:demo:pump:v1",
+    "title": "Pump",
+    "securityDefinitions": {"nosec_sc": {"scheme": "nosec"}},
+    "security": ["nosec_sc"],
+    "properties": {
+        "rpm": {"type": "integer", "readOnly": True, "forms": [{"href": "local://rpm"}]},
+        "target_rpm": {"type": "integer", "forms": [{"href": "local://target_rpm"}]},
+    },
+    "actions": {
+        "set_speed": {
+            "input": {"type": "object", "properties": {"rpm": {"type": "integer"}}},
+            "forms": [{"href": "local://set_speed"}],
+        }
+    },
 }
 
 
 class Pump:
     def __init__(self):
         self._rpm = 0
-        self.target_rpm = 0          # plain attribute (LocalInvoker setattr path)
+        self.target_rpm = 0  # plain attribute (LocalInvoker setattr path)
 
     def rpm(self):
         return self._rpm

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -8,13 +8,16 @@ from thingctx import LocalInvoker, ThingClient
 
 TD = {
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
-    "id": "urn:demo:pump:v1", "title": "Pump",
-    "securityDefinitions": {"nosec_sc": {"scheme": "nosec"}}, "security": ["nosec_sc"],
+    "id": "urn:demo:pump:v1",
+    "title": "Pump",
+    "securityDefinitions": {"nosec_sc": {"scheme": "nosec"}},
+    "security": ["nosec_sc"],
     "actions": {
         "status": {"idempotent": True, "forms": [{"href": "local://status"}]},
-        "set_speed": {"input": {"type": "object",
-                      "properties": {"rpm": {"type": "integer"}}},
-                      "forms": [{"href": "local://set_speed"}]},
+        "set_speed": {
+            "input": {"type": "object", "properties": {"rpm": {"type": "integer"}}},
+            "forms": [{"href": "local://set_speed"}],
+        },
     },
 }
 
@@ -23,10 +26,12 @@ TD = {
 async def test_td_becomes_callable_mcp_tools():
     pytest.importorskip("mcp")
     from mcp.shared.memory import create_connected_server_and_client_session as connect
+
     from thingctx.integrations.mcp import build_mcp_server
 
-    inv = LocalInvoker({"status": lambda: {"rpm": 0},
-                        "set_speed": lambda rpm=0: {"ok": True, "rpm": rpm}})
+    inv = LocalInvoker(
+        {"status": lambda: {"rpm": 0}, "set_speed": lambda rpm=0: {"ok": True, "rpm": rpm}}
+    )
     server = build_mcp_server(ThingClient(tds=[TD], invokers=[inv]), name="pump")
     async with connect(server) as s:
         await s.initialize()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,16 +4,22 @@ from __future__ import annotations
 
 import json
 
-import thingctx
 from thingctx import FileRegistry, ThingClient
 
 
 def test_file_registry_loads_a_folder(tmp_path):
-    (tmp_path / "a.td.json").write_text(json.dumps({
-        "@context": "https://www.w3.org/2022/wot/td/v1.1",
-        "id": "urn:x:a:v1", "title": "A",
-        "securityDefinitions": {"nosec_sc": {"scheme": "nosec"}}, "security": ["nosec_sc"],
-        "actions": {"ping": {"forms": [{"href": "local://ping"}]}}}))
+    (tmp_path / "a.td.json").write_text(
+        json.dumps(
+            {
+                "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                "id": "urn:x:a:v1",
+                "title": "A",
+                "securityDefinitions": {"nosec_sc": {"scheme": "nosec"}},
+                "security": ["nosec_sc"],
+                "actions": {"ping": {"forms": [{"href": "local://ping"}]}},
+            }
+        )
+    )
     tds = FileRegistry(str(tmp_path)).fetch()
     assert len(tds) == 1 and tds[0]["id"] == "urn:x:a:v1"
     client = ThingClient.from_registry(FileRegistry(str(tmp_path)))


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI workflow that runs on push and PR to `main`:
  - **lint** job: `ruff check` + `ruff format --check`
  - **test** job: `pytest` across Python 3.10 / 3.11 / 3.12, with `network`-marked tests deselected so CI stays hermetic
- Adopt **ruff** as linter + formatter: `[tool.ruff]` config (line length 100, py310 target, rules `E/F/I/UP/B`), added to the `dev` extra.
- Apply ruff's autofixes and formatting across the tree (PEP 604 optionals, unquoted annotations, sorted imports, dropped dead imports, consistent formatting). No behavior change.

## Test plan
- [x] `ruff check .` — all checks pass
- [x] `ruff format --check .` — all files formatted
- [x] `pytest -m "not network"` — green (8 passed)