### PR TITLE
fix: use the official W3C TD 1.1 validation schema

### DIFF
--- a/src/thingctx/data/td-schema-1.1.json
+++ b/src/thingctx/data/td-schema-1.1.json
@@ -1,9 +1,9 @@
 {
   "title": "Thing Description",
-  "version": "1.1-09-November-2023",
+  "version": "1.1-12-March-2025",
   "description": "JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id":"https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",
+  "$id": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",
   "definitions": {
     "anyUri": {
       "type": "string"
@@ -33,7 +33,7 @@
           "items": {
             "type": "string"
           },
-          "minItems":1
+          "minItems": 1
         },
         {
           "type": "string"
@@ -76,7 +76,7 @@
     "thing-context": {
       "anyOf": [
         {
-          "$comment":"New context URI with other vocabularies after it but not the old one",
+          "$comment": "New context URI with other vocabularies after it but not the old one",
           "type": "array",
           "items": [
             {
@@ -89,22 +89,25 @@
                 "$ref": "#/definitions/anyUri"
               },
               {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             ],
-            "not":{
+            "not": {
               "$ref": "#/definitions/thing-context-td-uri-v1"
             }
           }
         },
         {
-          "$comment":"Only the new context URI",
+          "$comment": "Only the new context URI",
           "$ref": "#/definitions/thing-context-td-uri-v1.1"
         },
         {
-          "$comment":"Old context URI, followed by the new one and possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
+          "$comment": "Old context URI, followed by the new one and possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
           "type": "array",
-          "prefixItems": [
+          "items": [
             {
               "$ref": "#/definitions/thing-context-td-uri-v1"
             },
@@ -112,17 +115,17 @@
               "$ref": "#/definitions/thing-context-td-uri-v1.1"
             }
           ],
-          "minItems":2,
-          "contains":{
-            "$ref": "#/definitions/thing-context-td-uri-v1.1"
-          },
+          "minItems": 2,
           "additionalItems": {
             "anyOf": [
               {
                 "$ref": "#/definitions/anyUri"
               },
               {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             ]
           }
@@ -130,31 +133,34 @@
         {
           "$comment": "Old context URI, followed by possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
           "type": "array",
-          "prefixItems": [{
-            "$ref": "#/definitions/thing-context-td-uri-v1"
-          }],
-          "minItems": 1,
-          "contains": {
-            "$ref": "#/definitions/thing-context-td-uri-v1"
-          },
-          "additionalItems": {
-            "anyOf": [{
-              "$ref": "#/definitions/anyUri"
-            },
+          "items": [
             {
-              "type": "object"
+              "$ref": "#/definitions/thing-context-td-uri-v1"
             }
-           ]
+          ],
+          "minItems": 1,
+          "additionalItems": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/anyUri"
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            ]
           }
         },
         {
-          "$comment":"Only the old context URI",
+          "$comment": "Only the old context URI",
           "$ref": "#/definitions/thing-context-td-uri-v1"
         }
       ]
     },
-    "bcp47_string":{
-      "type":"string",
+    "bcp47_string": {
+      "type": "string",
       "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
     },
     "type_declaration": {
@@ -379,7 +385,11 @@
       "additionalProperties": true
     },
     "form_element_property": {
-      "allOf":[{"$ref":"#/definitions/form_element_base"}],
+      "allOf": [
+        {
+          "$ref": "#/definitions/form_element_base"
+        }
+      ],
       "type": "object",
       "properties": {
         "op": {
@@ -412,7 +422,11 @@
       "additionalProperties": true
     },
     "form_element_action": {
-      "allOf":[{"$ref":"#/definitions/form_element_base"}],
+      "allOf": [
+        {
+          "$ref": "#/definitions/form_element_base"
+        }
+      ],
       "type": "object",
       "properties": {
         "op": {
@@ -443,7 +457,11 @@
       "additionalProperties": true
     },
     "form_element_event": {
-      "allOf":[{"$ref":"#/definitions/form_element_base"}],
+      "allOf": [
+        {
+          "$ref": "#/definitions/form_element_base"
+        }
+      ],
       "type": "object",
       "properties": {
         "op": {
@@ -472,7 +490,11 @@
       "additionalProperties": true
     },
     "form_element_root": {
-      "allOf":[{"$ref":"#/definitions/form_element_base"}],
+      "allOf": [
+        {
+          "$ref": "#/definitions/form_element_base"
+        }
+      ],
       "type": "object",
       "properties": {
         "op": {
@@ -513,16 +535,26 @@
         }
       },
       "additionalProperties": true,
-      "required":["op"]
+      "required": [
+        "op"
+      ]
     },
-    "form" : {
-      "$comment":"This is NOT for validation purposes but for automatic generation of TS types. For more info, please see: https://github.com/w3c/wot-thing-description/pull/1319#issuecomment-994950057",
+    "form": {
+      "$comment": "This is NOT for validation purposes but for automatic generation of TS types. For more info, please see: https://github.com/w3c/wot-thing-description/pull/1319#issuecomment-994950057",
       "oneOf": [
-           {  "$ref" : "#/definitions/form_element_property" },
-           {  "$ref" : "#/definitions/form_element_action" },
-           {  "$ref" : "#/definitions/form_element_event" },
-           {  "$ref" : "#/definitions/form_element_root" }
-       ]
+        {
+          "$ref": "#/definitions/form_element_property"
+        },
+        {
+          "$ref": "#/definitions/form_element_action"
+        },
+        {
+          "$ref": "#/definitions/form_element_event"
+        },
+        {
+          "$ref": "#/definitions/form_element_root"
+        }
+      ]
     },
     "property_element": {
       "type": "object",
@@ -764,15 +796,17 @@
           "$ref": "#/definitions/anyUri"
         },
         "hreflang": {
-            "anyOf":[
-              {"$ref": "#/definitions/bcp47_string"},
-              {
-                "type":"array",
-                "items":{
-                  "$ref": "#/definitions/bcp47_string"
-                }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/bcp47_string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/bcp47_string"
               }
-            ]
+            }
+          ]
         }
       },
       "required": [
@@ -844,7 +878,10 @@
           "scheme": "ace:ACESecurityScheme",
           "ace:as": "coaps://as.example.com/token",
           "ace:audience": "coaps://rs.example.com",
-          "ace:scopes": ["limited", "special"],
+          "ace:scopes": [
+            "limited",
+            "special"
+          ],
           "ace:cnonce": true
         }
       ],
@@ -921,8 +958,10 @@
           ]
         }
       },
-      "not":{
-        "required":["name"]
+      "not": {
+        "required": [
+          "name"
+        ]
       },
       "required": [
         "scheme"
@@ -1368,13 +1407,13 @@
         ]
       }
     },
-        "forms": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/form_element_root"
-          }
-        },
+    "forms": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/form_element_root"
+      }
+    },
     "base": {
       "$ref": "#/definitions/anyUri"
     },

--- a/src/thingctx/validate.py
+++ b/src/thingctx/validate.py
@@ -1,5 +1,6 @@
-"""Validate a TD against the bundled W3C WoT TD 1.1 schema (REC,
-2023-11-09). Needs the [validate] extra (jsonschema).
+"""Validate a TD against the bundled W3C WoT TD 1.1 schema
+(1.1-12-March-2025, official W3C validation schema). Needs the [validate]
+extra (jsonschema).
 
     problems = validate_td(my_td)        # [] if conformant
     thingctx.from_td(td, validate=True)  # raises TDValidationError

--- a/tests/test_schema_current.py
+++ b/tests/test_schema_current.py
@@ -1,0 +1,34 @@
+"""The bundled TD 1.1 schema must stay byte-identical to the official W3C
+validation schema. This is the drift tripwire: if W3C republishes, this
+fails so the bundled copy gets refreshed instead of silently going stale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from thingctx.validate import _SCHEMA_PATH
+
+# Official W3C WoT TD 1.1 validation schema (302s to the versioned raw file).
+W3C_TD_SCHEMA_URL = "https://www.w3.org/2022/wot/td-schema/v1.1"
+
+
+@pytest.mark.network
+def test_bundled_schema_matches_w3c_upstream():
+    httpx = pytest.importorskip("httpx")
+    try:
+        resp = httpx.get(W3C_TD_SCHEMA_URL, follow_redirects=True, timeout=10)
+        resp.raise_for_status()
+    except httpx.HTTPError as e:
+        pytest.skip(f"cannot reach W3C schema source: {e}")
+
+    upstream = resp.content
+    bundled = _SCHEMA_PATH.read_bytes()
+    if hashlib.sha256(bundled).digest() != hashlib.sha256(upstream).digest():
+        pytest.fail(
+            "bundled TD 1.1 schema has drifted from the official W3C schema.\n"
+            f"  refresh: curl -sL {W3C_TD_SCHEMA_URL} -o {_SCHEMA_PATH}\n"
+            "  then review the diff and bump the date in validate.py."
+        )


### PR DESCRIPTION
Swaps the bundled TD 1.1 schema for the official W3C validation schema (1.1-12-March-2025) verbatim, plus a network-gated test that flags upstream drift.

Closes #1.