### PR TITLE
ci: add a ci-ok aggregator gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,18 @@ jobs:
           pip install -e ".[dev]"
       - name: Test (offline)
         run: pytest -m "not network" -q
+
+  # Single stable gate to require in branch protection, so the matrix can
+  # change without touching the protected-branch config.
+  ci-ok:
+    name: ci-ok
+    if: always()
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check upstream jobs
+        run: |
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ]; then
+            echo "lint=${{ needs.lint.result }} test=${{ needs.test.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
Adds a single `ci-ok` job that passes only when `lint` and `test` succeed.

Lets branch protection require one stable check instead of the version-pinned matrix names.