### PR TITLE
feat: per-Thing credential resolution for multi-Thing clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,10 @@ __pycache__/
 dist/
 build/
 
+# Local secrets , never commit (.env.example template is fine)
+.env
+.env.local
+.env.*.local
+
 # Agent contract / internal instructions , never public
 .claude/

--- a/src/thingctx/integrations/mcp.py
+++ b/src/thingctx/integrations/mcp.py
@@ -21,10 +21,31 @@ In an MCP client config (e.g. Claude CLI .mcp.json):
 
 from __future__ import annotations
 
+import os
 import sys
 from typing import Any
 
 from thingctx.runtime import ThingClient, to_text
+
+
+def _credentials_from_env() -> dict[str, str]:
+    """Collect per-Thing secrets from the environment.
+
+    ``THINGCTX_TOKEN_<SLUG>=<secret>`` binds a secret to the Thing whose slug
+    is ``<SLUG>`` (lowercased, with ``_`` mapped to ``-`` so
+    ``THINGCTX_TOKEN_GOOGLE_MAPS`` -> ``google-maps``). The slug is the same
+    one used in tool names. The secret is applied per the Thing's declared
+    scheme (bearer/basic/apikey). Secrets live only in the process
+    environment -- never in a TD or on disk here.
+    """
+    prefix = "THINGCTX_TOKEN_"
+    creds: dict[str, str] = {}
+    for key, val in os.environ.items():
+        if key.startswith(prefix) and val:
+            slug = key[len(prefix) :].lower().replace("_", "-")
+            if slug:
+                creds[slug] = val
+    return creds
 
 
 def build_mcp_server(client: ThingClient, *, name: str = "thingctx"):
@@ -153,10 +174,21 @@ def client_from_registry(registry, credentials: dict | None = None) -> ThingClie
 
 
 async def serve(registry) -> None:
-    """Run the stdio MCP server over a registry of TDs."""
+    """Run the stdio MCP server over a registry of TDs.
+
+    Per-Thing secrets are read from the environment (THINGCTX_TOKEN_<SLUG>)
+    and bound to each Thing's declared security scheme, so authenticated
+    surfaces are drivable without baking secrets into any TD.
+    """
     from mcp.server.stdio import stdio_server
 
-    client = client_from_registry(registry)
+    creds = _credentials_from_env()
+    client = client_from_registry(registry, credentials=creds)
+    if creds:
+        print(
+            f"thingctx-mcp: loaded {len(creds)} credential(s) for {', '.join(sorted(creds))}",
+            file=sys.stderr,
+        )
     n = len(client.things)
     name = client.things[0].title if n == 1 else f"things ({n})"
     server = build_mcp_server(client, name=name or "things")

--- a/src/thingctx/invokers.py
+++ b/src/thingctx/invokers.py
@@ -164,10 +164,12 @@ class LocalInvoker:
 class HttpInvoker:
     """POST the action input as JSON to the form's http(s) URL.
 
-    Honors TD-declared security: pass ``credentials={scheme_name: secret}``
-    and, when a parsed :class:`WoTThing` is bound (via ``with_security``),
-    the matching auth header is applied per request. The TD names the
-    scheme; you supply the secret.
+    Honors TD-declared security. Bind one Thing with ``with_security`` or a
+    whole fleet with ``with_things``; each request then authenticates as the
+    Thing that owns the action being invoked. Supply secrets in
+    ``credentials``, keyed by Thing id, Thing slug, or scheme name (looked up
+    in that order) -- so a multi-Thing client can carry a different secret per
+    Thing. The TD names the scheme; you supply the secret.
     """
 
     scheme = "http"
@@ -184,6 +186,9 @@ class HttpInvoker:
         self._credentials = credentials or {}
         self._schemes_by_name: dict = {}  # set by with_security()
         self._active: tuple = ()
+        # thing_id -> (active security names, schemes_by_name); set by
+        # with_security/with_things so auth resolves per owning Thing.
+        self._things_by_id: dict = {}
         # This invoker also claims https.
         self.schemes = ("http", "https")
 
@@ -192,17 +197,55 @@ class HttpInvoker:
         carry the right auth. Returns self (chainable)."""
         self._schemes_by_name = dict(getattr(thing, "security_schemes", {}) or {})
         self._active = tuple(getattr(thing, "security", ()) or ())
+        self._register(thing)
         return self
 
-    def _auth(self) -> tuple[dict, dict]:
-        """Build (extra_headers, query_params) from the active scheme +
-        the supplied credential."""
+    def with_things(self, things) -> HttpInvoker:
+        """Bind many Things so each request authenticates as the Thing that
+        owns the action. Returns self (chainable)."""
+        for thing in things or ():
+            self._register(thing)
+        return self
+
+    def _register(self, thing) -> None:
+        tid = getattr(thing, "id", None)
+        if tid is None:
+            return
+        self._things_by_id[tid] = (
+            tuple(getattr(thing, "security", ()) or ()),
+            dict(getattr(thing, "security_schemes", {}) or {}),
+        )
+
+    @staticmethod
+    def _slug(thing_id: str) -> str:
+        """Thing-id -> short slug, matching the tool-name scheme
+        (urn:thingctx:google-maps -> google-maps)."""
+        parts = [p for p in str(thing_id).split(":") if p]
+        if len(parts) >= 2 and parts[-1].lower().lstrip("v").isdigit():
+            parts = parts[:-1]
+        slug = parts[-1] if parts else str(thing_id)
+        return "".join(c if (c.isalnum() or c in "._-") else "-" for c in slug)
+
+    def _auth(self, owner_id: str | None = None) -> tuple[dict, dict]:
+        """Build (extra_headers, query_params) for the Thing that owns the
+        interaction. Resolves that Thing's active scheme(s) and the matching
+        secret (by Thing id, then slug, then scheme name)."""
         headers: dict = {}
         params: dict = {}
-        for sname in self._active:
-            scheme = self._schemes_by_name.get(sname)
-            secret = self._credentials.get(sname)
-            if scheme is None or secret is None or scheme.scheme == "nosec":
+        active, schemes = self._active, self._schemes_by_name
+        if owner_id is not None and owner_id in self._things_by_id:
+            active, schemes = self._things_by_id[owner_id]
+        slug = self._slug(owner_id) if owner_id is not None else None
+        for sname in active:
+            scheme = schemes.get(sname)
+            if scheme is None or scheme.scheme == "nosec":
+                continue
+            secret = None
+            for key in (owner_id, slug, sname):
+                if key is not None and key in self._credentials:
+                    secret = self._credentials[key]
+                    break
+            if secret is None:
                 continue
             if scheme.scheme == "bearer":
                 headers["Authorization"] = f"Bearer {secret}"
@@ -218,15 +261,15 @@ class HttpInvoker:
                     headers[scheme.key_name] = secret
         return headers, params
 
-    def _hp(self):
+    def _hp(self, owner_id: str | None = None):
         """Merge static headers with TD-security auth to (headers, params)."""
-        auth_h, params = self._auth()
+        auth_h, params = self._auth(owner_id)
         return {**self._headers, **auth_h}, params
 
     async def invoke(self, action, form, arguments):  # noqa: ANN001
         import httpx
 
-        headers, params = self._hp()
+        headers, params = self._hp(getattr(action, "thing_id", None))
         # WoT HTTP binding: honor the form's declared method, else default
         # by safety. Idempotent (safe) actions GET with args as query
         # params; others POST with a JSON body.
@@ -255,7 +298,7 @@ class HttpInvoker:
         """GET the property's current value from its form URL."""
         import httpx
 
-        headers, params = self._hp()
+        headers, params = self._hp(getattr(prop, "thing_id", None))
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             resp = await client.get(form.href, headers=headers, params=params)
             resp.raise_for_status()
@@ -266,7 +309,7 @@ class HttpInvoker:
         ``writeproperty`` HTTP binding default)."""
         import httpx
 
-        headers, params = self._hp()
+        headers, params = self._hp(getattr(prop, "thing_id", None))
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             resp = await client.put(
                 form.href,

--- a/src/thingctx/runtime.py
+++ b/src/thingctx/runtime.py
@@ -57,14 +57,15 @@ class ThingClient:
                 self._props[_tool_name(thing.id, p.name)] = p
             for e in thing.events.values():
                 self._events[_tool_name(thing.id, e.name)] = e
-        # Bind the TD's declared security to any invoker that honors it,
-        # so requests carry the right auth without the adopter wiring it.
-        # (Single-Thing common case; the first Thing's schemes apply.)
-        if self._things:
-            thing = self._things[0]
-            for inv in self._invokers:
-                if hasattr(inv, "with_security"):
-                    inv.with_security(thing)
+        # Bind the TDs' declared security to any invoker that honors it, so
+        # requests carry the right auth without the adopter wiring it. A
+        # fleet-aware invoker (with_things) authenticates each call as its
+        # owning Thing; otherwise fall back to the first Thing's schemes.
+        for inv in self._invokers:
+            if hasattr(inv, "with_things"):
+                inv.with_things(self._things)
+            elif hasattr(inv, "with_security") and self._things:
+                inv.with_security(self._things[0])
 
         # Preferred transport order = the order invokers were given.
         self._prefer = tuple(

--- a/tests/test_invoker_auth.py
+++ b/tests/test_invoker_auth.py
@@ -1,0 +1,103 @@
+"""Per-Thing auth resolution for HttpInvoker.
+
+A multi-Thing client shares one HttpInvoker, so each request must
+authenticate as the Thing that owns the action -- with its own secret and
+its own declared scheme. These cases lock that in (offline; no requests are
+made -- we assert the headers/params the invoker would attach).
+"""
+
+from __future__ import annotations
+
+import base64
+
+from thingctx.invokers import HttpInvoker
+from thingctx.runtime import ThingClient
+
+
+def _td(slug: str, scheme: dict, security: str = "sc") -> dict:
+    """Minimal TD with a single GET action `ping` and one security scheme."""
+    return {
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "id": f"urn:thingctx:{slug}",
+        "title": slug,
+        "securityDefinitions": {security: scheme},
+        "security": [security],
+        "actions": {
+            "ping": {"forms": [{"href": f"https://api.example/{slug}", "htv:methodName": "GET"}]}
+        },
+    }
+
+
+def _headers_for(http: HttpInvoker, client: ThingClient, tool: str):
+    """(headers, params) the invoker would send for `tool`."""
+    action = client.action_for(tool)
+    return http._hp(action.thing_id)
+
+
+def test_bearer_resolves_distinct_secret_per_thing():
+    http = HttpInvoker(credentials={"alpha": "AAA", "beta": "BBB"})
+    client = ThingClient(
+        tds=[_td("alpha", {"scheme": "bearer"}), _td("beta", {"scheme": "bearer"})],
+        invokers=[http],
+    )
+    ha, _ = _headers_for(http, client, "alpha.ping")
+    hb, _ = _headers_for(http, client, "beta.ping")
+    assert ha["Authorization"] == "Bearer AAA"
+    assert hb["Authorization"] == "Bearer BBB"
+
+
+def test_apikey_query_and_header():
+    http = HttpInvoker(credentials={"mapsvc": "GKEY", "searchsvc": "BKEY"})
+    client = ThingClient(
+        tds=[
+            _td("mapsvc", {"scheme": "apikey", "in": "query", "name": "key"}),
+            _td("searchsvc", {"scheme": "apikey", "in": "header", "name": "X-Token"}),
+        ],
+        invokers=[http],
+    )
+    hq, pq = _headers_for(http, client, "mapsvc.ping")
+    hh, ph = _headers_for(http, client, "searchsvc.ping")
+    assert pq["key"] == "GKEY" and "Authorization" not in hq
+    assert hh["X-Token"] == "BKEY" and ph == {}
+
+
+def test_basic_is_base64_encoded():
+    http = HttpInvoker(credentials={"acct": "user:pass"})
+    client = ThingClient(tds=[_td("acct", {"scheme": "basic"})], invokers=[http])
+    h, _ = _headers_for(http, client, "acct.ping")
+    assert h["Authorization"] == "Basic " + base64.b64encode(b"user:pass").decode()
+
+
+def test_nosec_thing_gets_no_auth():
+    http = HttpInvoker(credentials={"openthing": "ignored"})
+    client = ThingClient(tds=[_td("openthing", {"scheme": "nosec"})], invokers=[http])
+    h, p = _headers_for(http, client, "openthing.ping")
+    assert "Authorization" not in h and p == {}
+
+
+def test_missing_credential_sends_no_header():
+    http = HttpInvoker(credentials={})
+    client = ThingClient(tds=[_td("alpha", {"scheme": "bearer"})], invokers=[http])
+    h, _ = _headers_for(http, client, "alpha.ping")
+    assert "Authorization" not in h
+
+
+def test_legacy_scheme_name_keying_still_works():
+    # Single-Thing adopters key credentials by scheme name, not Thing slug.
+    http = HttpInvoker(credentials={"sc": "LEGACY"})
+    client = ThingClient(tds=[_td("alpha", {"scheme": "bearer"})], invokers=[http])
+    h, _ = _headers_for(http, client, "alpha.ping")
+    assert h["Authorization"] == "Bearer LEGACY"
+
+
+def test_one_thing_secret_does_not_leak_to_another():
+    # alpha has a secret; beta does not -> beta must send no auth.
+    http = HttpInvoker(credentials={"alpha": "AAA"})
+    client = ThingClient(
+        tds=[_td("alpha", {"scheme": "bearer"}), _td("beta", {"scheme": "bearer"})],
+        invokers=[http],
+    )
+    ha, _ = _headers_for(http, client, "alpha.ping")
+    hb, _ = _headers_for(http, client, "beta.ping")
+    assert ha["Authorization"] == "Bearer AAA"
+    assert "Authorization" not in hb


### PR DESCRIPTION
Resolves credentials per Thing so one client (or MCP server) can drive many authenticated Things without leaking secrets between them. Adds regression tests.