### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thingctx"
-version = "0.1.0"
+version = "0.1.1"
 description = "Drive any agent against any W3C WoT Thing, over any transport. No per-integration server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -44,7 +44,7 @@ from thingctx.thing import (
 )
 from thingctx.validate import TDValidationError, validate_td
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "from_url",


### PR DESCRIPTION
Bumps the package version to 0.1.1 for the first PyPI release.