### PR TITLE
docs: concise PyPI description + bump to 0.1.2

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -1,0 +1,37 @@
+# thingctx
+
+Drive any agent against any W3C Web of Things Thing, over any transport.
+The integration is a JSON Thing Description, not a server you run.
+
+## Install
+
+    pip install thingctx[all]
+    # or pick extras: thingctx[llm] [http] [mqtt] [validate] [mcp]
+
+## Use
+
+```python
+import thingctx
+
+# Out-of-the-box agent loop
+host = await thingctx.from_url("https://api.example.com/.well-known/wot")
+print(await host.chat("what's the forecast for Cairo?"))
+```
+
+Own the loop? Get tool specs and route calls yourself:
+
+```python
+client = thingctx.ThingClient.from_registry(thingctx.from_arg("./registry/"))
+specs, invoke = client.as_tools()
+await invoke("pump.set_speed", {"rpm": 1500})
+```
+
+Closed agent (Claude Desktop, Copilot)? Bridge a registry of descriptions to MCP:
+
+    thingctx-mcp ./registry/
+
+## Docs and source
+
+Full README, examples, and design notes: https://github.com/thingctx/thingctx
+
+Apache-2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "thingctx"
 version = "0.1.1"
 description = "Drive any agent against any W3C WoT Thing, over any transport. No per-integration server."
-readme = "README.md"
+readme = "README-pypi.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [{ name = "The thingctx Authors" }]
@@ -20,6 +20,10 @@ classifiers = [
 # Core is stdlib-only. Everything else is an opt-in extra so the
 # package stays light and dependency-free at its core.
 dependencies = []
+
+[project.urls]
+Homepage = "https://thingctx.com"
+Repository = "https://github.com/thingctx/thingctx"
 
 [project.optional-dependencies]
 # The LLM loop (any provider via litellm).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thingctx"
-version = "0.1.1"
+version = "0.1.2"
 description = "Drive any agent against any W3C WoT Thing, over any transport. No per-integration server."
 readme = "README-pypi.md"
 requires-python = ">=3.10"

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -44,7 +44,7 @@ from thingctx.thing import (
 )
 from thingctx.validate import TDValidationError, validate_td
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     "from_url",


### PR DESCRIPTION
PyPI's long_description now points at a short, usage-first README-pypi.md, with Homepage/Repository URLs; the full README.md stays for GitHub. Bumps to 0.1.2 so the new description ships on the next release.