### PR TITLE
ci: publish a GitHub Release per tag after PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,22 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  # Publish a GitHub Release for the tag after PyPI succeeds. Authored by
+  # github-actions[bot] (no personal account), with auto-generated notes and
+  # the built artifacts attached.
+  github-release:
+    name: github release
+    needs: pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
After PyPI publishes, create the tag's GitHub Release (auto notes + built artifacts) as github-actions[bot].