### PR TITLE
Measure MCP (stdio/http) vs thingctx; fix live-registry quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,17 @@ calling isn't available.
 
 ## Why not MCP
 
-To expose a system over MCP you write a server, deploy it, and keep it
-running, one per integration. N systems means N processes to operate. A Thing
-Description is a static file: write it (or generate it), check it into git, or
-serve it from a URL. There is nothing to run, nothing to keep alive.
-Integration becomes data, not a service, and data scales to a fleet for free.
+MCP solves the wrong problem. Calling a real system from a model was always a
+tooling limitation, not a protocol one: read an interface, hand the model tool
+specs, route each call to its transport , all client-side, drivable from a plain
+description. MCP turns that gap into infrastructure you operate instead of data
+you read.
+
+To expose a system over MCP you write a server, deploy it, and keep it running,
+one per integration. N systems means N processes to operate. A Thing Description
+is a static file: write it (or generate it), check it into git, or serve it from
+a URL. There is nothing to run, nothing to keep alive. Integration becomes data,
+not a service, and data scales to a fleet for free.
 
 A messy device (binary protocol, a session dance) gets one thin connector that
 exposes a clean WoT face; the TD describes *that*. The connector is consumed
@@ -116,7 +122,21 @@ See [`examples/01_mcp_baseline.py`](examples/01_mcp_baseline.py) (a server per
 integration) and
 [`examples/02_thingctx_baseline.py`](examples/02_thingctx_baseline.py) (no
 server). Both drive the same pump; every result is asserted equal to calling
-the system directly.
+the system directly. The difference is what you build and run to get there:
+
+| per integration     | MCP (stdio) | MCP (http)   | thingctx |
+| -------------------- | ----------- | ------------ | -------- |
+| server process       | per session | 1, long-run  | 0        |
+| hand-written lines   | 142         | 142          | 10       |
+| time to first call   | 540 ms      | 13 ms        | 2 ms     |
+
+thingctx calls in milliseconds because there is no server to start. MCP needs
+one, and the transport sets the cost: stdio spawns it per session (the first
+call pays process startup, 540 ms), streamable-HTTP is a server you keep running
+and connect to (13 ms, warm). Once connected, per-call latency is small for all
+three; the difference is the server you build and run to get there. The Thing
+Description is data, about 145 lines of JSON, written once and read by every
+consumer. Reproduce with `python examples/_measure.py`.
 
 ## Reference
 

--- a/examples/_mcp_http_server.py
+++ b/examples/_mcp_http_server.py
@@ -1,0 +1,49 @@
+"""A real streamable-HTTP MCP server for the pump, reusing 01's build_server.
+
+Unlike stdio (spawned by the client per session), an HTTP MCP server is a
+long-running process you operate; clients connect to it over the wire. The
+measurement starts this once and then times only connect + initialize +
+first call, the per-session latency against a warm server.
+
+Env: PUMP_HTTP / PUMP_MQTT (device endpoints), MCP_PORT (listen port).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _pump import PumpDevice  # noqa: E402
+
+
+def build_app():
+    import uvicorn
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+
+    mod = importlib.import_module("01_mcp_baseline")
+    pump = PumpDevice()
+    server = mod.build_server(pump, os.environ["PUMP_HTTP"], os.environ["PUMP_MQTT"])
+    manager = StreamableHTTPSessionManager(app=server, json_response=True, stateless=True)
+
+    async def handle(scope, receive, send):
+        await manager.handle_request(scope, receive, send)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(app):
+        async with manager.run():
+            yield
+
+    app = Starlette(routes=[Mount("/mcp", app=handle)], lifespan=lifespan)
+    return uvicorn, app
+
+
+if __name__ == "__main__":
+    uvicorn, app = build_app()
+    uvicorn.run(app, host="127.0.0.1", port=int(os.environ["MCP_PORT"]), log_level="warning")

--- a/examples/_mcp_stdio_server.py
+++ b/examples/_mcp_stdio_server.py
@@ -1,0 +1,33 @@
+"""A real stdio MCP server for the pump, reusing 01's build_server, so the
+measurement can spawn it as a separate process and time a true MCP cold
+start (process + import + handshake), not the in-memory shortcut.
+
+The device's live endpoints arrive via the environment (PUMP_HTTP /
+PUMP_MQTT); local actions run against this process's own PumpDevice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _pump import PumpDevice  # noqa: E402
+
+
+async def serve() -> None:
+    from mcp.server.stdio import stdio_server
+
+    mod = importlib.import_module("01_mcp_baseline")
+    pump = PumpDevice()
+    server = mod.build_server(pump, os.environ["PUMP_HTTP"], os.environ["PUMP_MQTT"])
+    async with stdio_server() as (read, write):
+        await server.run(read, write, server.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(serve())

--- a/examples/_measure.py
+++ b/examples/_measure.py
@@ -1,0 +1,252 @@
+"""Measure 01 (MCP) vs 02 (thingctx) on the SAME pump, for the README.
+
+Three numbers, both paths driving the identical device:
+
+  processes  servers you author + run per integration
+  lines      hand-written integration code (non-blank, non-comment),
+             excluding docstrings and the shared Thing Description (data)
+  ttfc       time-to-first-call: wall-clock from "begin integrating" to the
+             first action result, median of N runs (device startup excluded,
+             it is the shared external world both paths consume)
+
+Run::  python examples/_measure.py
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import contextlib
+import os
+import socket
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from _pump import DEVICE_TOKEN, PumpDevice, start_device
+
+HERE = Path(__file__).parent
+RUNS = 9
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _device_env(td) -> dict:
+    http_url = td["base"].rstrip("/")
+    mqtt_addr = td["actions"]["set_coolant"]["forms"][0]["href"].split("//")[1].split("/")[0]
+    return {**os.environ, "PUMP_HTTP": http_url, "PUMP_MQTT": mqtt_addr}
+
+
+# ---- lines: count authored integration code, fairly ----
+
+
+def _code_lines(path: Path, node_filter) -> int:
+    """Non-blank, non-comment physical lines of the matching top-level
+    node(s), minus their docstring lines. This is the code a human writes
+    and maintains for the integration."""
+    src = path.read_text()
+    lines = src.splitlines()
+    tree = ast.parse(src)
+    total = 0
+    for node in ast.walk(tree):
+        if not node_filter(node):
+            continue
+        start, end = node.lineno, node.end_lineno
+        doc = ast.get_docstring(node, clean=False)
+        doc_span: set[int] = set()
+        if doc and node.body:
+            d = node.body[0]
+            doc_span = set(range(d.lineno, (d.end_lineno or d.lineno) + 1))
+        for i in range(start, end + 1):
+            if i in doc_span:
+                continue
+            s = lines[i - 1].strip()
+            if not s or s.startswith("#"):
+                continue
+            total += 1
+    return total
+
+
+def lines_mcp() -> int:
+    # the MCP server you author per integration: build_server(...)
+    return _code_lines(
+        HERE / "01_mcp_baseline.py",
+        lambda n: isinstance(n, ast.FunctionDef) and n.name == "build_server",
+    )
+
+
+def lines_thingctx() -> int:
+    # what you author to consume the TD: the ThingClient(...) setup + import.
+    src = (HERE / "02_thingctx_baseline.py").read_text()
+    lines = src.splitlines()
+    tree = ast.parse(src)
+    count = 0
+    for node in ast.walk(tree):
+        # the `from thingctx import ...` line
+        if isinstance(node, ast.ImportFrom) and node.module == "thingctx":
+            count += 1
+        # the `client = ThingClient(...)` assignment
+        if (
+            isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and getattr(node.value.func, "id", "") == "ThingClient"
+        ):
+            for i in range(node.lineno, (node.end_lineno or node.lineno) + 1):
+                s = lines[i - 1].strip()
+                if s and not s.startswith("#"):
+                    count += 1
+    return count
+
+
+def td_json_lines() -> int:
+    return len((HERE / "pump.td.json").read_text().splitlines())
+
+
+# ---- ttfc: time from "begin integrating" to first action result ----
+
+
+async def ttfc_mcp(pump, td) -> float:
+    """build the MCP server + open a session + initialize + first call_tool.
+    In-memory transport: a LOWER BOUND (real MCP spawns a process / opens a
+    stdio or http transport, which costs more)."""
+    import importlib
+
+    mod = importlib.import_module("01_mcp_baseline")
+    from mcp.shared.memory import create_connected_server_and_client_session as connect
+
+    http_url = td["base"].rstrip("/")
+    mqtt_addr = td["actions"]["set_coolant"]["forms"][0]["href"].split("//")[1].split("/")[0]
+    t0 = time.perf_counter()
+    server = mod.build_server(pump, http_url, mqtt_addr)
+    async with connect(server) as session:
+        await session.initialize()
+        await session.call_tool("set_speed", {"rpm": 900})
+    return time.perf_counter() - t0
+
+
+async def ttfc_mcp_stdio(_pump, td) -> float:
+    """stdio MCP: the client SPAWNS the server per session, so every first
+    call pays process startup + the stdio handshake , the real cost to stand
+    up one stdio integration."""
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(
+        command=sys.executable, args=[str(HERE / "_mcp_stdio_server.py")], env=_device_env(td)
+    )
+    t0 = time.perf_counter()
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            await session.call_tool("set_speed", {"rpm": 900})
+    return time.perf_counter() - t0
+
+
+async def ttfc_mcp_http(url: str) -> float:
+    """streamable-HTTP MCP: the server is already running (a process you
+    operate). Time only connect + initialize + first call , the per-session
+    latency a client pays against a warm server."""
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    t0 = time.perf_counter()
+    async with streamablehttp_client(url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            await session.call_tool("set_speed", {"rpm": 900})
+    return time.perf_counter() - t0
+
+
+def start_http_mcp(td) -> tuple[subprocess.Popen, str]:
+    """Bring up the long-running HTTP MCP server; return (proc, url) once it
+    is accepting connections."""
+    port = _free_port()
+    env = {**_device_env(td), "MCP_PORT": str(port)}
+    proc = subprocess.Popen([sys.executable, str(HERE / "_mcp_http_server.py")], env=env)
+    for _ in range(100):
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                break
+        except OSError:
+            time.sleep(0.1)
+    time.sleep(0.5)  # let the ASGI app finish its lifespan startup
+    return proc, f"http://127.0.0.1:{port}/mcp"
+
+
+async def ttfc_thingctx(pump, td) -> float:
+    """consume the TD (validate against the W3C schema) + first invoke."""
+    from thingctx import HttpInvoker, LocalInvoker, MqttInvoker, ThingClient
+
+    t0 = time.perf_counter()
+    client = ThingClient(
+        tds=[td],
+        invokers=[
+            LocalInvoker(pump),
+            HttpInvoker(credentials={"bearer_sc": DEVICE_TOKEN}),
+            MqttInvoker(timeout=5),
+        ],
+        validate=True,
+    )
+    await client.invoke("pump.set_speed", {"rpm": 900})
+    return time.perf_counter() - t0
+
+
+async def median_ttfc(fn, td) -> float:
+    samples = []
+    for _ in range(RUNS + 1):  # +1 warmup, dropped
+        pump = PumpDevice()
+        samples.append(await fn(pump, td))
+    return statistics.median(samples[1:]) * 1000.0  # ms
+
+
+async def median_http(url: str) -> float:
+    samples = []
+    for _ in range(RUNS + 1):  # +1 warmup, dropped
+        samples.append(await ttfc_mcp_http(url))
+    return statistics.median(samples[1:]) * 1000.0  # ms
+
+
+async def main() -> None:
+    sys.path.insert(0, str(HERE))  # so importlib finds 01_mcp_baseline
+
+    proc, td, stop = None, None, None
+    _, td, stop = start_device()
+    try:
+        mcp_stdio_ms = await median_ttfc(ttfc_mcp_stdio, td)
+        proc, url = start_http_mcp(td)
+        mcp_http_ms = await median_http(url)
+        mcp_mem_ms = await median_ttfc(ttfc_mcp, td)
+        tc_ms = await median_ttfc(ttfc_thingctx, td)
+    finally:
+        if proc:
+            proc.terminate()
+            with contextlib.suppress(Exception):
+                proc.wait(timeout=5)
+        if stop:
+            stop()
+
+    lm, lt, ltd = lines_mcp(), lines_thingctx(), td_json_lines()
+
+    print(f"runs (median of {RUNS}, 1 warmup dropped)\n")
+    print(f"{'metric':<24}{'MCP stdio':>13}{'MCP http':>13}{'thingctx':>13}")
+    print("-" * 63)
+    print(f"{'server process':<24}{'per session':>13}{'1 (running)':>13}{'0':>13}")
+    print(f"{'hand-written lines':<24}{lm:>13}{lm:>13}{lt:>13}")
+    print(
+        f"{'time to first call':<24}{mcp_stdio_ms:>10.0f} ms"
+        f"{mcp_http_ms:>10.0f} ms{tc_ms:>10.1f} ms"
+    )
+    print(f"\n(Thing Description is data, shared by every consumer: {ltd} lines JSON.)")
+    print("(stdio MCP spawns the server per session, so its first call pays process")
+    print(" startup; http MCP is a warm long-running server, timed connect+init+call.")
+    print(f" In-memory MCP, no process or socket, is {mcp_mem_ms:.1f} ms , a floor.)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/thingctx/client.py
+++ b/src/thingctx/client.py
@@ -72,7 +72,9 @@ async def from_url(
     """
     import httpx
 
-    async with httpx.AsyncClient() as http:
+    from thingctx.registry import _user_agent
+
+    async with httpx.AsyncClient(headers={"User-Agent": _user_agent()}) as http:
         resp = await http.get(url)
         resp.raise_for_status()
         td = resp.json()

--- a/src/thingctx/registry.py
+++ b/src/thingctx/registry.py
@@ -94,8 +94,21 @@ def from_args(args: list[str]) -> Registry:
     return regs[0] if len(regs) == 1 else _Multi(regs)
 
 
+def _user_agent() -> str:
+    """A real User-Agent. Some hosts (e.g. Cloudflare) reject the default
+    ``Python-urllib/x.y`` UA with HTTP 403, which would break fetching a TD
+    from a hosted registry."""
+    try:
+        from importlib.metadata import version
+
+        return f"thingctx/{version('thingctx')}"
+    except Exception:  # noqa: BLE001
+        return "thingctx"
+
+
 def _get_json(url: str, timeout: float):
     import urllib.request
 
-    with urllib.request.urlopen(url, timeout=timeout) as r:
+    req = urllib.request.Request(url, headers={"User-Agent": _user_agent()})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
         return json.loads(r.read().decode())

--- a/src/thingctx/runtime.py
+++ b/src/thingctx/runtime.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from thingctx.invokers import Invoker, select_invoker
+from thingctx.invokers import HttpInvoker, Invoker, LocalInvoker, select_invoker
 from thingctx.thing import (
     WoTAction,
     WoTThing,
@@ -41,7 +41,11 @@ class ThingClient:
         # validate=True checks each TD against the W3C TD 1.1 schema and
         # raises TDValidationError on nonconformance (needs [validate]).
         self._things: list[WoTThing] = [parse_thing(td, validate=validate) for td in tds]
-        self._invokers = list(invokers or [])
+        # Default to HTTP + local so the documented quickstart (consume a TD,
+        # then invoke) routes without manual wiring; matches from_url. Pass
+        # invokers=[] explicitly for a client that registers none, or add
+        # MQTT/others as needed.
+        self._invokers = list(invokers) if invokers is not None else [HttpInvoker(), LocalInvoker()]
         self._tool_specs, self._route = actions_to_tools(
             self._things,
             only_idempotent=only_idempotent,

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,0 +1,50 @@
+"""Quickstart hardening: the documented consume-then-invoke path routes
+without manual invoker wiring, and TD fetches send a real User-Agent (some
+hosts, e.g. Cloudflare, reject the default urllib UA with HTTP 403)."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.request
+
+from thingctx import ThingClient
+from thingctx.registry import _get_json, _user_agent
+
+NOSEC_TD = {
+    "@context": "https://www.w3.org/2022/wot/td/v1.1",
+    "id": "urn:demo:svc:v1",
+    "title": "Svc",
+    "securityDefinitions": {"nosec_sc": {"scheme": "nosec"}},
+    "security": ["nosec_sc"],
+    "actions": {
+        "ping": {"forms": [{"href": "https://example.invalid/ping", "htv:methodName": "GET"}]}
+    },
+}
+
+
+def test_default_invokers_when_none():
+    c = ThingClient(tds=[NOSEC_TD])  # no invokers passed: should default
+    kinds = {type(i).__name__ for i in c._invokers}
+    assert "HttpInvoker" in kinds and "LocalInvoker" in kinds
+
+
+def test_explicit_empty_invokers_stays_empty():
+    c = ThingClient(tds=[NOSEC_TD], invokers=[])
+    assert c._invokers == []
+
+
+def test_user_agent_string():
+    assert _user_agent().startswith("thingctx")
+
+
+def test_fetch_sends_user_agent(monkeypatch):
+    seen = {}
+
+    def fake_urlopen(req, timeout=None):
+        seen["ua"] = req.get_header("User-agent")
+        return io.BytesIO(json.dumps({"ok": True}).encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert _get_json("https://example.invalid/x", 5) == {"ok": True}
+    assert seen["ua"] and seen["ua"].startswith("thingctx")


### PR DESCRIPTION
## Summary
- **docs**: add a reproducible harness (`examples/_measure.py` plus stdio and streamable-HTTP MCP server entry points) and record the figures in the README — one pump, both paths, every result asserted equal to a direct call. Lead "Why not MCP" with the thesis that calling a system from a model is a tooling limitation, not a protocol one.
- **fix**: send a `thingctx/<version>` User-Agent on TD fetches (`registry._get_json` and `from_url`). The hosted registry sits behind Cloudflare, which 403s the default `Python-urllib` UA, so consuming a hosted TD failed.
- **fix**: default `ThingClient` invokers to `[HttpInvoker, LocalInvoker]` when none are passed (matching `from_url`), so the documented consume-then-invoke quickstart routes without manual wiring. Pass `invokers=[]` for none.

## Test plan
- [x] `pytest -q` green (adds `tests/test_quickstart.py`: default invokers + UA on fetch)
- [x] `ruff check` / `ruff format --check` clean
- [x] Verified end to end from a clean 3.12 venv installing `thingctx[all]` from PyPI: consumed live TDs from td.thingctx.com and made a real Open-Meteo (`nosec`) call
- [x] `python examples/_measure.py` reproduces the README figures