### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thingctx"
-version = "0.1.2"
+version = "0.1.3"
 description = "Drive any agent against any W3C WoT Thing, over any transport. No per-integration server."
 readme = "README-pypi.md"
 requires-python = ">=3.10"

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -44,7 +44,7 @@ from thingctx.thing import (
 )
 from thingctx.validate import TDValidationError, validate_td
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = [
     "from_url",


### PR DESCRIPTION
Release 0.1.3. Bumps `pyproject.toml` and `thingctx.__version__`.

Ships the live-quickstart fixes from #12:
- TD fetches send a `thingctx/<version>` User-Agent (Cloudflare 403'd the default urllib UA).
- `ThingClient` defaults to `[HttpInvoker, LocalInvoker]` so the documented consume-then-invoke quickstart routes without manual wiring.

After merge, tag `v0.1.3` triggers the TestPyPI smoke + PyPI publish pipeline.