### PR TITLE
feat: trust & grounding (approval gating + verify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,45 @@ await client.read_property("pump.rpm")
 
 Add a Thing by pointing at one more description.
 
+## Safe by default: approval + grounding
+
+Two opt-in layers stand between an agent and a real system.
+
+**Approval** gates risky calls behind a human or a policy. Risk is read from the
+TD (`tc:requiresApproval`, or `@type tc:Destructive`) and from a policy you pick:
+
+```python
+def approve(req):                      # sync or async; return True to allow
+    return input(f"run {req.tool_name}{req.arguments}? [y/N] ").lower() == "y"
+
+client = thingctx.ThingClient(
+    tds=[td], invokers=[...], approve=approve, approve_when="declared")
+
+await client.invoke("pump.estop")      # asks approve() first; if denied, never runs
+```
+
+`approve_when` is `declared` (default, only TD-marked risky actions),
+`destructive` (the above plus any non-idempotent action and every property
+write), `all`, or `never`. A gated call with no approver is **denied** , a gate
+with nobody to open it stays shut. The check sits in `ThingClient.invoke`, so it
+applies to the LLM loop and to direct callers alike.
+
+**Grounding** checks a description against the *live* Thing before you trust it.
+`verify()` reads every readable property and confirms it answers and matches its
+declared type. It is read-only and safe , actions are never invoked.
+
+```python
+for report in await client.verify():
+    assert report.ok, report.as_dict()
+```
+
+The gate is on `ThingClient.invoke`, so it holds for any caller , a hand loop,
+the LLM host, or an MCP client (Claude/Copilot CLI; see
+[Reach a closed agent](#reach-a-closed-agent-the-mcp-bridge) below).
+
+Runnable: [`examples/04_trust.py`](examples/04_trust.py). Full model:
+[`docs/TRUST.md`](docs/TRUST.md).
+
 ## Reach a closed agent: the MCP bridge
 
 Some agents are closed: you can't hand their model tools directly, only
@@ -95,6 +134,17 @@ thingctx-mcp ./examples/registry/        # a folder, a URL, or a TD Directory
 ```json
 { "mcpServers": { "things": { "command": "thingctx-mcp",
   "args": ["./examples/registry/"] } } }
+```
+
+Risky tools are gated here too (see [Safe by default](#safe-by-default-approval--grounding)
+above): the bridge sends MCP destructive hints and asks the client to confirm a
+gated call (elicitation); decline , or a client that can't ask , means denied.
+Pick the policy with `THINGCTX_APPROVE_WHEN` (`declared` default, or
+`destructive` / `all` / `never`):
+
+```json
+{ "mcpServers": { "things": { "command": "thingctx-mcp", "args": ["./examples/registry/"],
+  "env": { "THINGCTX_APPROVE_WHEN": "destructive" } } } }
 ```
 
 MCP is just one way to deliver the description, for agents where direct tool

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -1,0 +1,183 @@
+# Trust: approval and grounding
+
+## Scope
+
+This document specifies the two trust primitives a consumer applies when it lets
+an agent drive a real system from a [W3C Thing
+Description](https://www.w3.org/TR/wot-thing-description11/): **approval gating**
+of risky calls, and **grounding** a description against the live Thing.
+
+Both are opt-in, have no LLM dependency, and are implemented in
+`thingctx.trust` and surfaced on `ThingClient`. They are defined one layer above
+the Thing Description and its transport bindings, and are not otherwise
+standardized.
+
+A Thing Description is data: it can be authored anywhere and may drift from the
+system it describes. The grounding check exists because a description is trusted
+only insofar as it still matches reality. The approval gate exists because some
+actions change the world and an agent should not be the only thing deciding to
+run them.
+
+## Approval gating
+
+### Risk
+
+An action is *risky* when either holds:
+
+- The Thing Description marks it so: `tc:requiresApproval` is truthy on the
+  action, or its `@type` includes `tc:Destructive`.
+- A non-idempotent action is treated as destructive (`is_destructive()`), since
+  re-running it is not safe.
+
+A property write is always a state mutation and is risky under the wider
+policies.
+
+### Policy
+
+`ThingClient(approve=..., approve_when=<policy>)` selects when the approver is
+consulted:
+
+| policy        | gated calls                                                            |
+| ------------- | ---------------------------------------------------------------------- |
+| `declared`    | actions the TD marks risky (`tc:requiresApproval` / `tc:Destructive`)  |
+| `destructive` | the above, plus any non-idempotent action and every property write     |
+| `all`         | every action and every property write                                  |
+| `never`       | nothing (gating off)                                                   |
+
+`declared` is the default. It honors exactly what the description author marked,
+and adds no friction to actions they declared safe.
+
+### Approver
+
+The approver is any callable, sync or async, that receives an `ApprovalRequest`
+and returns truthy to allow the call:
+
+```python
+@dataclass
+class ApprovalRequest:
+    tool_name: str            # e.g. "pump.estop"
+    arguments: dict           # the call arguments (or {"value": ...} for a write)
+    thing_id: str
+    action_name: str
+    reason: str               # why approval was required
+    description: str
+```
+
+### Default deny
+
+When a call is gated but **no approver is configured**, the call is denied and
+returns an error envelope rather than running. A gate with nobody to open it
+stays shut. To run risky calls without a prompt, set `approve_when="never"`
+explicitly, which records the intent in code.
+
+### Outcome
+
+The gate is enforced inside `ThingClient.invoke` and `write_property`, so it
+applies uniformly to the LLM tool-calling loop and to direct callers. A blocked
+call returns a structured envelope and never reaches the transport:
+
+```python
+{"error": "approval required but no approver configured", "tool": "pump.estop",
+ "reason": "TD-declared (tc:requiresApproval / tc:Destructive)", "hint": "..."}
+{"error": "approval denied", "tool": "pump.estop", "reason": "..."}
+```
+
+## Grounding
+
+### What verify() checks
+
+`await client.verify(thing_id=None)` grounds each Thing against its live
+endpoint and returns one report per Thing. For every **readable** property it:
+
+1. reads the current value over the property's transport, and
+2. checks the value against the property's declared type, when that type is a
+   scalar (`integer`, `number`, `string`, `boolean`).
+
+The check is lenient: an absent or non-scalar declared type passes, so an
+object- or array-valued property is grounded by a successful read alone. A read
+that returns an error envelope, or raises, fails that check.
+
+Actions are **never invoked** , invoking has side effects, so grounding is
+read-only and safe to run against production. Actions are validated structurally
+when the TD is parsed (and against the W3C schema with `validate=True`), not by
+exercising them.
+
+### Report
+
+```python
+@dataclass
+class Check:
+    target: str               # e.g. "property:rpm"
+    ok: bool
+    detail: str
+
+@dataclass
+class VerifyReport:
+    thing_id: str
+    ok: bool                  # True iff every check passed
+    checks: list[Check]
+    def __bool__(self) -> bool: ...
+    def as_dict(self) -> dict: ...
+```
+
+```python
+for report in await client.verify():
+    if not report:
+        print("drifted:", report.as_dict())
+```
+
+## Over the MCP bridge (Claude / Copilot CLI)
+
+The bridge (`thingctx-mcp`) executes every tool call through the same
+`ThingClient.invoke`, so the gate protects MCP clients exactly as it protects a
+direct caller. Two layers apply:
+
+1. **Client-side hints.** Each tool is annotated with `destructiveHint`,
+   `idempotentHint`, and `readOnlyHint`, derived from the TD (`is_destructive()`
+   / `idempotent`). Claude/Copilot CLI use these to prompt before a risky tool.
+2. **Server-side enforcement.** When a gated call runs, the bridge asks the
+   connected client to confirm via **MCP elicitation**. Accept lets the call
+   proceed; decline, cancel, or a client that cannot elicit means the call is
+   denied and never reaches the device.
+
+The policy is set with the `THINGCTX_APPROVE_WHEN` environment variable
+(`declared` default, or `destructive` / `all` / `never`). Mark risky actions in
+the TD for the `declared` policy:
+
+```json
+{ "actions": { "reboot": { "@type": "tc:Destructive",
+  "forms": [{ "href": "https://device.local/reboot" }] } } }
+```
+
+`.mcp.json` for a CLI, gating any non-idempotent call:
+
+```json
+{ "mcpServers": { "things": {
+    "command": "thingctx-mcp",
+    "args": ["./registry/"],
+    "env": { "THINGCTX_APPROVE_WHEN": "destructive" } } } }
+```
+
+A custom approver (audit log, out-of-band confirm) can replace elicitation:
+`build_mcp_server(client, approve=my_callable)`.
+
+## API summary
+
+| name                              | purpose                                         |
+| --------------------------------- | ----------------------------------------------- |
+| `ThingClient(approve=, approve_when=)` | wire the gate                              |
+| `ApprovalRequest`                 | what the approver is asked to allow             |
+| `client.verify(thing_id=None)`    | ground TD(s) against the live Thing             |
+| `VerifyReport`, `Check`           | grounding results                               |
+
+## Notes and limits
+
+- Grounding checks declared **scalar** types only; it does not validate nested
+  object or array schemas against live values. A successful read is the signal
+  for those.
+- Risk is read from the description and policy; thingctx does not infer that an
+  un-annotated, idempotent action is dangerous. Mark such actions in the TD, or
+  widen `approve_when`.
+- The approver is the integration point for a UI, an audit log, or an
+  out-of-band confirmation. thingctx supplies the request and enforces the
+  verdict; it does not prescribe how the decision is made.

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -1,183 +1,66 @@
 # Trust: approval and grounding
 
-## Scope
-
-This document specifies the two trust primitives a consumer applies when it lets
-an agent drive a real system from a [W3C Thing
-Description](https://www.w3.org/TR/wot-thing-description11/): **approval gating**
-of risky calls, and **grounding** a description against the live Thing.
-
-Both are opt-in, have no LLM dependency, and are implemented in
-`thingctx.trust` and surfaced on `ThingClient`. They are defined one layer above
-the Thing Description and its transport bindings, and are not otherwise
-standardized.
-
-A Thing Description is data: it can be authored anywhere and may drift from the
-system it describes. The grounding check exists because a description is trusted
-only insofar as it still matches reality. The approval gate exists because some
-actions change the world and an agent should not be the only thing deciding to
-run them.
+Two opt-in primitives for letting an agent drive a real system from a TD:
+**approval gating** of risky calls and **grounding** a TD against the live Thing.
+Both have no LLM dependency, live in `thingctx.trust`, and are surfaced on
+`ThingClient`.
 
 ## Approval gating
 
-### Risk
+A call is *risky* when the TD marks it (`tc:requiresApproval`, or `@type`
+includes `tc:Destructive`), when an action is non-idempotent, or when it writes a
+property. `ThingClient(approve=<callable>, approve_when=<policy>)` picks when the
+approver is consulted:
 
-An action is *risky* when either holds:
+| policy | gated calls |
+|---|---|
+| `declared` (default) | actions the TD marks risky |
+| `destructive` | the above + any non-idempotent action and every property write |
+| `all` | every action and every property write |
+| `never` | nothing (gating off) |
 
-- The Thing Description marks it so: `tc:requiresApproval` is truthy on the
-  action, or its `@type` includes `tc:Destructive`.
-- A non-idempotent action is treated as destructive (`is_destructive()`), since
-  re-running it is not safe.
+The approver is any callable (sync or async) that receives an `ApprovalRequest`
+(`tool_name`, `arguments`, `thing_id`, `action_name`, `reason`) and returns
+truthy to allow the call. Gating is enforced inside `invoke` / `write_property`,
+so it applies to the LLM tool-loop and direct callers alike.
 
-A property write is always a state mutation and is risky under the wider
-policies.
-
-### Policy
-
-`ThingClient(approve=..., approve_when=<policy>)` selects when the approver is
-consulted:
-
-| policy        | gated calls                                                            |
-| ------------- | ---------------------------------------------------------------------- |
-| `declared`    | actions the TD marks risky (`tc:requiresApproval` / `tc:Destructive`)  |
-| `destructive` | the above, plus any non-idempotent action and every property write     |
-| `all`         | every action and every property write                                  |
-| `never`       | nothing (gating off)                                                   |
-
-`declared` is the default. It honors exactly what the description author marked,
-and adds no friction to actions they declared safe.
-
-### Approver
-
-The approver is any callable, sync or async, that receives an `ApprovalRequest`
-and returns truthy to allow the call:
-
-```python
-@dataclass
-class ApprovalRequest:
-    tool_name: str            # e.g. "pump.estop"
-    arguments: dict           # the call arguments (or {"value": ...} for a write)
-    thing_id: str
-    action_name: str
-    reason: str               # why approval was required
-    description: str
-```
-
-### Default deny
-
-When a call is gated but **no approver is configured**, the call is denied and
-returns an error envelope rather than running. A gate with nobody to open it
-stays shut. To run risky calls without a prompt, set `approve_when="never"`
-explicitly, which records the intent in code.
-
-### Outcome
-
-The gate is enforced inside `ThingClient.invoke` and `write_property`, so it
-applies uniformly to the LLM tool-calling loop and to direct callers. A blocked
-call returns a structured envelope and never reaches the transport:
-
-```python
-{"error": "approval required but no approver configured", "tool": "pump.estop",
- "reason": "TD-declared (tc:requiresApproval / tc:Destructive)", "hint": "..."}
-{"error": "approval denied", "tool": "pump.estop", "reason": "..."}
-```
+**Default deny:** if a call is gated but no approver is configured, it returns an
+error envelope instead of running. Set `approve_when="never"` to run risky calls
+without a prompt.
 
 ## Grounding
 
-### What verify() checks
-
-`await client.verify(thing_id=None)` grounds each Thing against its live
-endpoint and returns one report per Thing. For every **readable** property it:
-
-1. reads the current value over the property's transport, and
-2. checks the value against the property's declared type, when that type is a
-   scalar (`integer`, `number`, `string`, `boolean`).
-
-The check is lenient: an absent or non-scalar declared type passes, so an
-object- or array-valued property is grounded by a successful read alone. A read
-that returns an error envelope, or raises, fails that check.
-
-Actions are **never invoked** , invoking has side effects, so grounding is
-read-only and safe to run against production. Actions are validated structurally
-when the TD is parsed (and against the W3C schema with `validate=True`), not by
-exercising them.
-
-### Report
-
-```python
-@dataclass
-class Check:
-    target: str               # e.g. "property:rpm"
-    ok: bool
-    detail: str
-
-@dataclass
-class VerifyReport:
-    thing_id: str
-    ok: bool                  # True iff every check passed
-    checks: list[Check]
-    def __bool__(self) -> bool: ...
-    def as_dict(self) -> dict: ...
-```
+`await client.verify(thing_id=None)` returns a `VerifyReport` per Thing. For each
+**readable** property it reads the live value and checks it against the declared
+type when that type is scalar. The check is lenient (absent/non-scalar types pass
+on a successful read) and **read-only** — actions are never invoked, so it is
+safe against production.
 
 ```python
 for report in await client.verify():
-    if not report:
+    if not report:                  # VerifyReport.__bool__ == all checks passed
         print("drifted:", report.as_dict())
 ```
 
-## Over the MCP bridge (Claude / Copilot CLI)
+## Over the MCP bridge
 
-The bridge (`thingctx-mcp`) executes every tool call through the same
-`ThingClient.invoke`, so the gate protects MCP clients exactly as it protects a
-direct caller. Two layers apply:
-
-1. **Client-side hints.** Each tool is annotated with `destructiveHint`,
-   `idempotentHint`, and `readOnlyHint`, derived from the TD (`is_destructive()`
-   / `idempotent`). Claude/Copilot CLI use these to prompt before a risky tool.
-2. **Server-side enforcement.** When a gated call runs, the bridge asks the
-   connected client to confirm via **MCP elicitation**. Accept lets the call
-   proceed; decline, cancel, or a client that cannot elicit means the call is
-   denied and never reaches the device.
-
-The policy is set with the `THINGCTX_APPROVE_WHEN` environment variable
-(`declared` default, or `destructive` / `all` / `never`). Mark risky actions in
-the TD for the `declared` policy:
-
-```json
-{ "actions": { "reboot": { "@type": "tc:Destructive",
-  "forms": [{ "href": "https://device.local/reboot" }] } } }
-```
-
-`.mcp.json` for a CLI, gating any non-idempotent call:
-
-```json
-{ "mcpServers": { "things": {
-    "command": "thingctx-mcp",
-    "args": ["./registry/"],
-    "env": { "THINGCTX_APPROVE_WHEN": "destructive" } } } }
-```
-
-A custom approver (audit log, out-of-band confirm) can replace elicitation:
-`build_mcp_server(client, approve=my_callable)`.
+The MCP bridge (`thingctx-mcp`) runs every tool call through the same
+`ThingClient.invoke`, so the gate protects MCP clients too. Tools carry
+`destructiveHint` / `idempotentHint` / `readOnlyHint` from the TD, and a gated
+call asks the client to confirm via MCP elicitation (decline, or a client that
+can't elicit, denies). Set the policy with `THINGCTX_APPROVE_WHEN`, or pass a
+custom approver: `build_mcp_server(client, approve=my_callable)`.
 
 ## API summary
 
-| name                              | purpose                                         |
-| --------------------------------- | ----------------------------------------------- |
-| `ThingClient(approve=, approve_when=)` | wire the gate                              |
-| `ApprovalRequest`                 | what the approver is asked to allow             |
-| `client.verify(thing_id=None)`    | ground TD(s) against the live Thing             |
-| `VerifyReport`, `Check`           | grounding results                               |
+| name | purpose |
+|---|---|
+| `ThingClient(approve=, approve_when=)` | wire the gate |
+| `ApprovalRequest` | what the approver is asked to allow |
+| `client.verify(thing_id=None)` | ground TD(s) against the live Thing |
+| `VerifyReport`, `Check` | grounding results |
 
-## Notes and limits
-
-- Grounding checks declared **scalar** types only; it does not validate nested
-  object or array schemas against live values. A successful read is the signal
-  for those.
-- Risk is read from the description and policy; thingctx does not infer that an
-  un-annotated, idempotent action is dangerous. Mark such actions in the TD, or
-  widen `approve_when`.
-- The approver is the integration point for a UI, an audit log, or an
-  out-of-band confirmation. thingctx supplies the request and enforces the
-  verdict; it does not prescribe how the decision is made.
+Risk is read from the TD and policy — thingctx does not infer that an
+un-annotated idempotent action is dangerous; mark it in the TD or widen
+`approve_when`. The approver is the integration point for a UI, audit log, or
+out-of-band confirmation.

--- a/examples/04_trust.py
+++ b/examples/04_trust.py
@@ -36,8 +36,10 @@ def safety_policy(deny: set[str]):
 
     def approve(req) -> bool:
         ok = req.action_name not in deny
-        print(f"    approver: {req.tool_name}{req.arguments}  reason={req.reason!r}  -> "
-              f"{'ALLOW' if ok else 'DENY'}")
+        print(
+            f"    approver: {req.tool_name}{req.arguments}  reason={req.reason!r}  -> "
+            f"{'ALLOW' if ok else 'DENY'}"
+        )
         return ok
 
     return approve
@@ -57,8 +59,9 @@ async def main() -> None:
     # one) but allows ordinary commands like set_speed.
     approve = safety_policy(deny={"estop"})
     try:
-        client = ThingClient(tds=[td], invokers=_invokers(pump),
-                             approve=approve, approve_when="destructive")
+        client = ThingClient(
+            tds=[td], invokers=_invokers(pump), approve=approve, approve_when="destructive"
+        )
 
         print("== Part A: the gate (no LLM) ==")
         ok = await client.invoke("pump.set_speed", {"rpm": 900})
@@ -83,12 +86,18 @@ async def main() -> None:
         if model is None:
             print("  (no LLM reachable; skipping. start Ollama qwen2.5:7b or set an API key.)")
         else:
-            host = thingctx.from_td(td, model=model, invokers=_invokers(pump),
-                                    approve=approve, approve_when="destructive",
-                                    resilient=True)
+            host = thingctx.from_td(
+                td,
+                model=model,
+                invokers=_invokers(pump),
+                approve=approve,
+                approve_when="destructive",
+                resilient=True,
+            )
             print(f"  model: {model}")
             answer = await host.chat(
-                "The pump is overheating. Emergency-stop it now by calling estop.")
+                "The pump is overheating. Emergency-stop it now by calling estop."
+            )
             print(f"  LLM -> {answer}")
             # The gate, not the model, is the guarantee: estop was denied.
             assert pump.stopped is False, "the gate must have blocked the LLM's estop"

--- a/examples/04_trust.py
+++ b/examples/04_trust.py
@@ -1,0 +1,108 @@
+"""04, trust: the safety layer that protects against a wrong decision , by a
+human, by an LLM, or by an MCP client (Claude / Copilot CLI).
+
+Same pump as 02/03. The new thing is a trust gate on the client:
+
+  - approval , a risky call (here, any non-idempotent action under the
+    "destructive" policy) is routed to an approver, which may deny it. A
+    denied call never reaches the device.
+  - grounding , verify() reads the TD against the live pump and reports whether
+    it still matches (declared types vs. real values).
+
+The same gate sits on ``ThingClient.invoke``, so it protects:
+  * a hand-written loop (Part A),
+  * an LLM driving the Thing (Part B), and
+  * an MCP client over the bridge (Part C note) , Claude/Copilot CLI calls go
+    through the same invoke path, and the bridge asks them to confirm a gated
+    call via MCP elicitation.
+
+Run::  python examples/04_trust.py
+       (Part B uses a local Ollama model or an API key if present; see _pump)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from _pump import DEVICE_TOKEN, pick_llm_model, start_device
+
+import thingctx
+from thingctx import HttpInvoker, LocalInvoker, MqttInvoker, ThingClient
+
+
+def safety_policy(deny: set[str]):
+    """A policy approver: deny the named (dangerous) actions, allow the rest.
+    Stands in for a human prompt or an audit rule. Prints each decision."""
+
+    def approve(req) -> bool:
+        ok = req.action_name not in deny
+        print(f"    approver: {req.tool_name}{req.arguments}  reason={req.reason!r}  -> "
+              f"{'ALLOW' if ok else 'DENY'}")
+        return ok
+
+    return approve
+
+
+def _invokers(pump):
+    return [
+        LocalInvoker(pump),
+        HttpInvoker(credentials={"bearer_sc": DEVICE_TOKEN}),
+        MqttInvoker(timeout=5),
+    ]
+
+
+async def main() -> None:
+    pump, td, stop = start_device()
+    # Gate every non-idempotent action; the policy denies estop (the dangerous
+    # one) but allows ordinary commands like set_speed.
+    approve = safety_policy(deny={"estop"})
+    try:
+        client = ThingClient(tds=[td], invokers=_invokers(pump),
+                             approve=approve, approve_when="destructive")
+
+        print("== Part A: the gate (no LLM) ==")
+        ok = await client.invoke("pump.set_speed", {"rpm": 900})
+        print(f"set_speed(900)  -> {ok}")
+        assert ok == {"ok": True, "rpm": 900}
+
+        blocked = await client.invoke("pump.estop", {"reason": "panic"})
+        print(f"estop()         -> {blocked}")
+        assert blocked["error"] == "approval denied"
+        assert pump.stopped is False, "the device must NOT have stopped"
+        print(f"device protected: pump.stopped == {pump.stopped} (estop never reached it)\n")
+
+        print("== grounding: verify() the TD against the live pump ==")
+        for report in await client.verify():
+            print(f"verify {report.thing_id} -> ok={report.ok}")
+            for c in report.checks:
+                print(f"    {c.target}: {'ok' if c.ok else 'FAIL'}  {c.detail}")
+        print()
+
+        print("== Part B: an LLM tries the wrong thing ==")
+        model = pick_llm_model()
+        if model is None:
+            print("  (no LLM reachable; skipping. start Ollama qwen2.5:7b or set an API key.)")
+        else:
+            host = thingctx.from_td(td, model=model, invokers=_invokers(pump),
+                                    approve=approve, approve_when="destructive",
+                                    resilient=True)
+            print(f"  model: {model}")
+            answer = await host.chat(
+                "The pump is overheating. Emergency-stop it now by calling estop.")
+            print(f"  LLM -> {answer}")
+            # The gate, not the model, is the guarantee: estop was denied.
+            assert pump.stopped is False, "the gate must have blocked the LLM's estop"
+            print(f"  device protected: pump.stopped == {pump.stopped} (gate denied the LLM)")
+
+        print("\n== Part C: same gate over MCP (Claude / Copilot CLI) ==")
+        print("  `thingctx-mcp <registry>` builds the same client; call_tool routes through")
+        print("  ThingClient.invoke, so gated tools are blocked there too. The bridge wires an")
+        print("  elicitation approver, so the CLI asks you to confirm. Set the policy with")
+        print("  THINGCTX_APPROVE_WHEN=declared|destructive|all|never. Mark risky actions in")
+        print("  the TD (tc:requiresApproval / @type tc:Destructive) for the 'declared' policy.")
+    finally:
+        stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ Run from the repo root with `PYTHONPATH=src`.
 | [01_mcp_baseline.py](01_mcp_baseline.py) | The MCP model: author + run a server. |
 | [02_thingctx_baseline.py](02_thingctx_baseline.py) | Same pump, no server. Read 01/02 back to back. |
 | [03_thingctx_llm.py](03_thingctx_llm.py) | Add an LLM (local Ollama or an API key). |
+| [04_trust.py](04_trust.py) | Approval gating + `verify()` grounding (no model). See [docs/TRUST.md](../docs/TRUST.md). |
 | [05_oauth2.py](05_oauth2.py) | A full OAuth2 client-credentials flow, offline: local token server + protected API, driven from a TD. |
 | [06_custom_auth.py](06_custom_auth.py) | Extensible auth: register a new security scheme, and use the built-in AWS SigV4 signer. Offline. |
 | [registry/](registry/) | Standalone TDs. Point `thingctx-mcp` or `from_registry` here. |

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -67,6 +67,11 @@ from thingctx.registry import (
     from_args,
 )
 from thingctx.runtime import ThingClient
+from thingctx.trust import (
+    ApprovalRequest,
+    Check,
+    VerifyReport,
+)
 from thingctx.thing import (
     WoTAction,
     WoTEvent,
@@ -133,4 +138,7 @@ __all__ = [
     "register_signer",
     "apply_mqtt",
     "MqttAuthPlan",
+    "ApprovalRequest",
+    "VerifyReport",
+    "Check",
 ]

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -67,11 +67,6 @@ from thingctx.registry import (
     from_args,
 )
 from thingctx.runtime import ThingClient
-from thingctx.trust import (
-    ApprovalRequest,
-    Check,
-    VerifyReport,
-)
 from thingctx.thing import (
     WoTAction,
     WoTEvent,
@@ -80,6 +75,11 @@ from thingctx.thing import (
     WoTThing,
     actions_to_tools,
     parse_thing,
+)
+from thingctx.trust import (
+    ApprovalRequest,
+    Check,
+    VerifyReport,
 )
 from thingctx.validate import TDValidationError, validate_td
 

--- a/src/thingctx/client.py
+++ b/src/thingctx/client.py
@@ -31,16 +31,21 @@ def from_td(
     model: str = "anthropic/claude-sonnet-4-6",
     invokers: list[Invoker] | None = None,
     validate: bool = False,
+    approve: Any = None,
+    approve_when: str = "declared",
     **host_kwargs: Any,
 ) -> LLMHost:
     """From one or more TD dicts. Defaults to HTTP + local invokers;
     pass ``invokers=`` for MQTT/CoAP/custom transports a TD uses.
-    ``validate=True`` checks each TD against the W3C TD 1.1 schema."""
+    ``validate=True`` checks each TD against the W3C TD 1.1 schema.
+    ``approve`` / ``approve_when`` gate risky calls (see thingctx.trust)."""
     tds = td if isinstance(td, list) else [td]
     client = ThingClient(
         tds=tds,
         invokers=invokers if invokers is not None else _default_invokers(),
         validate=validate,
+        approve=approve,
+        approve_when=approve_when,
     )
     return LLMHost(client, model=model, **host_kwargs)
 

--- a/src/thingctx/integrations/mcp.py
+++ b/src/thingctx/integrations/mcp.py
@@ -48,13 +48,54 @@ def _credentials_from_env() -> dict[str, str]:
     return creds
 
 
-def build_mcp_server(client: ThingClient, *, name: str = "thingctx"):
+def _elicit_approver(server):
+    """An approver that asks the connected MCP client (Claude/Copilot CLI) to
+    confirm a gated call, via MCP elicitation. Denies if the client cannot
+    elicit or there is no live session , a gate with nobody to open it stays
+    shut. This is the human-in-the-loop for the CLI integrations."""
+
+    async def approve(req) -> bool:
+        try:
+            session = server.request_context.session
+        except Exception:  # noqa: BLE001 , no active request/session
+            return False
+        message = (
+            f"Approve {req.tool_name}({req.arguments})?  "
+            f"Reason: {req.reason}."
+            + (f"  {req.description}" if req.description else "")
+        )
+        try:
+            # An empty object schema asks for a plain accept / decline / cancel.
+            result = await session.elicit(message=message, requestedSchema={
+                "type": "object", "properties": {}})
+        except Exception:  # noqa: BLE001 , client has no elicitation capability
+            return False
+        return getattr(result, "action", None) == "accept"
+
+    return approve
+
+
+def build_mcp_server(client: ThingClient, *, name: str = "thingctx", approve: Any = "elicit",
+                     approve_when: str | None = None):
     """Build an mcp Server that bridges `client` to MCP. Needs the `mcp`
-    package."""
+    package.
+
+    The trust gate (thingctx.trust) is enforced on the same ``client.invoke``
+    path used here, so risky tools are gated for MCP clients too. ``approve``:
+    ``"elicit"`` (default) asks the connected client to confirm a gated call;
+    a callable uses your own approver; ``None`` leaves the client's gate as-is.
+    ``approve_when`` overrides the client's policy (declared/destructive/all/never).
+    """
     import mcp.types as types
     from mcp.server.lowlevel import Server
 
     server: Server = Server(name)
+    if approve == "elicit":
+        client.set_approval(_elicit_approver(server), approve_when=approve_when)
+    elif callable(approve):
+        client.set_approval(approve, approve_when=approve_when)
+    elif approve_when is not None:
+        client.set_approval(client._approve, approve_when=approve_when)
 
     # actions -> tools, carrying MCP annotations so a client can gate or
     # label them. The common hints are derived from the TD's own
@@ -150,10 +191,13 @@ def build_mcp_server(client: ThingClient, *, name: str = "thingctx"):
     return server
 
 
-def client_from_registry(registry, credentials: dict | None = None) -> ThingClient:
+def client_from_registry(
+    registry, credentials: dict | None = None, approve_when: str = "declared"
+) -> ThingClient:
     """Build one ThingClient over all the TDs a registry yields, with the
     invokers whose deps are installed (local always; http/mqtt if
-    importable). `registry` is anything with a fetch() -> list[dict]."""
+    importable). `registry` is anything with a fetch() -> list[dict].
+    ``approve_when`` sets the trust policy (the MCP server wires the approver)."""
     from thingctx.invokers import LocalInvoker
 
     tds = registry.fetch()
@@ -170,7 +214,7 @@ def client_from_registry(registry, credentials: dict | None = None) -> ThingClie
         invokers.append(MqttInvoker())
     except Exception:  # noqa: BLE001
         pass
-    return ThingClient(tds=tds, invokers=invokers)
+    return ThingClient(tds=tds, invokers=invokers, approve_when=approve_when)
 
 
 async def serve(registry) -> None:
@@ -183,12 +227,17 @@ async def serve(registry) -> None:
     from mcp.server.stdio import stdio_server
 
     creds = _credentials_from_env()
-    client = client_from_registry(registry, credentials=creds)
+    # Trust policy from the environment; default "declared" honors exactly what
+    # each TD marks risky. The server wires an elicitation approver, so a gated
+    # tool prompts the CLI user to confirm before it runs.
+    approve_when = os.environ.get("THINGCTX_APPROVE_WHEN", "declared")
+    client = client_from_registry(registry, credentials=creds, approve_when=approve_when)
     if creds:
         print(
             f"thingctx-mcp: loaded {len(creds)} credential(s) for {', '.join(sorted(creds))}",
             file=sys.stderr,
         )
+    print(f"thingctx-mcp: approval policy = {approve_when}", file=sys.stderr)
     n = len(client.things)
     name = client.things[0].title if n == 1 else f"things ({n})"
     server = build_mcp_server(client, name=name or "things")

--- a/src/thingctx/integrations/mcp.py
+++ b/src/thingctx/integrations/mcp.py
@@ -86,18 +86,20 @@ def build_mcp_server(
 
     The trust gate (thingctx.trust) is enforced on the same ``client.invoke``
     path used here, so risky tools are gated for MCP clients too. ``approve``:
-    ``"elicit"`` (default) asks the connected client to confirm a gated call;
-    a callable uses your own approver; ``None`` leaves the client's gate as-is.
-    ``approve_when`` overrides the client's policy (declared/destructive/all/never).
+    ``"elicit"`` (default) asks the connected client to confirm a gated call,
+    but only installs elicitation when the client has no approver yet, so an
+    approver the caller already configured is never clobbered; a callable uses
+    your own approver; ``None`` leaves the client's gate as-is. ``approve_when``
+    overrides the client's policy (declared/destructive/all/never).
     """
     import mcp.types as types
     from mcp.server.lowlevel import Server
 
     server: Server = Server(name)
-    if approve == "elicit":
-        client.set_approval(_elicit_approver(server), approve_when=approve_when)
-    elif callable(approve):
+    if callable(approve):
         client.set_approval(approve, approve_when=approve_when)
+    elif approve == "elicit" and client._approve is None:
+        client.set_approval(_elicit_approver(server), approve_when=approve_when)
     elif approve_when is not None:
         client.set_approval(client._approve, approve_when=approve_when)
 

--- a/src/thingctx/integrations/mcp.py
+++ b/src/thingctx/integrations/mcp.py
@@ -59,15 +59,14 @@ def _elicit_approver(server):
             session = server.request_context.session
         except Exception:  # noqa: BLE001 , no active request/session
             return False
-        message = (
-            f"Approve {req.tool_name}({req.arguments})?  "
-            f"Reason: {req.reason}."
-            + (f"  {req.description}" if req.description else "")
+        message = f"Approve {req.tool_name}({req.arguments})?  Reason: {req.reason}." + (
+            f"  {req.description}" if req.description else ""
         )
         try:
             # An empty object schema asks for a plain accept / decline / cancel.
-            result = await session.elicit(message=message, requestedSchema={
-                "type": "object", "properties": {}})
+            result = await session.elicit(
+                message=message, requestedSchema={"type": "object", "properties": {}}
+            )
         except Exception:  # noqa: BLE001 , client has no elicitation capability
             return False
         return getattr(result, "action", None) == "accept"
@@ -75,8 +74,13 @@ def _elicit_approver(server):
     return approve
 
 
-def build_mcp_server(client: ThingClient, *, name: str = "thingctx", approve: Any = "elicit",
-                     approve_when: str | None = None):
+def build_mcp_server(
+    client: ThingClient,
+    *,
+    name: str = "thingctx",
+    approve: Any = "elicit",
+    approve_when: str | None = None,
+):
     """Build an mcp Server that bridges `client` to MCP. Needs the `mcp`
     package.
 

--- a/src/thingctx/runtime.py
+++ b/src/thingctx/runtime.py
@@ -18,6 +18,14 @@ from thingctx.thing import (
     actions_to_tools,
     parse_thing,
 )
+from thingctx.trust import (
+    ApprovePolicy,
+    Approver,
+    VerifyReport,
+    gate_action,
+    gate_write,
+    verify_thing,
+)
 
 
 class ThingClient:
@@ -37,9 +45,18 @@ class ThingClient:
         invokers: list[Invoker] | None = None,
         only_idempotent: bool = False,
         validate: bool = False,
+        approve: Approver | None = None,
+        approve_when: ApprovePolicy = "declared",
     ) -> None:
         # validate=True checks each TD against the W3C TD 1.1 schema and
         # raises TDValidationError on nonconformance (needs [validate]).
+        #
+        # approve / approve_when gate risky calls behind a human/policy: see
+        # thingctx.trust. With approve_when="declared" (default) only actions
+        # the TD marks risky are gated, and a gated call with no approver is
+        # denied (a safe default). approve_when="never" disables the gate.
+        self._approve = approve
+        self._approve_when: ApprovePolicy = approve_when
         self._things: list[WoTThing] = [parse_thing(td, validate=validate) for td in tds]
         # Default to HTTP + local so the documented quickstart (consume a TD,
         # then invoke) routes without manual wiring; matches from_url. Pass
@@ -96,6 +113,16 @@ class ThingClient:
     def things(self) -> list[WoTThing]:
         return self._things
 
+    def set_approval(
+        self, approve: Approver | None, *, approve_when: ApprovePolicy | None = None
+    ) -> None:
+        """Set or replace the approval gate after construction. The MCP bridge
+        uses this to bind an approver to the live server session (which does
+        not exist when the client is built)."""
+        self._approve = approve
+        if approve_when is not None:
+            self._approve_when = approve_when
+
     async def invoke(self, tool_name: str, arguments: dict[str, Any] | None = None) -> Any:
         """Invoke one action by routing to the transport its form names.
         ``arguments`` defaults to ``{}`` (for no-input actions)."""
@@ -103,6 +130,11 @@ class ThingClient:
         action = self._route.get(tool_name)
         if action is None:
             return {"error": f"unknown action: {tool_name}"}
+        blocked = await gate_action(
+            action, tool_name, arguments, approve=self._approve, policy=self._approve_when
+        )
+        if blocked is not None:
+            return blocked
         form = action.primary_form(prefer=self._prefer)
         if form is None:
             return {"error": f"action {tool_name} has no form (no transport)"}
@@ -145,6 +177,11 @@ class ThingClient:
             return {"error": f"unknown property: {name}"}
         if not prop.writable:
             return {"error": f"property {name} is read-only"}
+        blocked = await gate_write(
+            prop.thing_id, name, value, approve=self._approve, policy=self._approve_when
+        )
+        if blocked is not None:
+            return blocked
         form = prop.primary_form(prefer=self._prefer)
         invoker = select_invoker(self._invokers, form) if form else None
         if invoker is None or not hasattr(invoker, "write"):
@@ -167,6 +204,18 @@ class ThingClient:
             return _empty_aiter(f"no subscribable transport for {name}")
         bare = target.name
         return await invoker.subscribe(bare, form)
+
+    async def verify(self, thing_id: str | None = None) -> list[VerifyReport]:
+        """Ground each Thing's TD against the live endpoint: read every
+        readable property and check it answers and matches its declared type.
+        Read-only and safe (actions are never invoked). Returns one report per
+        Thing; ``thing_id`` limits it to a single Thing.
+
+            for report in await client.verify():
+                assert report.ok, report.as_dict()
+        """
+        things = [t for t in self._things if thing_id is None or t.id == thing_id]
+        return [await verify_thing(self, t) for t in things]
 
 
 async def _empty_aiter(err: str):

--- a/src/thingctx/trust.py
+++ b/src/thingctx/trust.py
@@ -15,9 +15,9 @@ Both are opt-in and have no LLM dependency.
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from thingctx.thing import WoTAction

--- a/src/thingctx/trust.py
+++ b/src/thingctx/trust.py
@@ -1,0 +1,212 @@
+"""Trust + grounding.
+
+Two safety primitives a consumer needs before it lets an agent drive a Thing:
+
+- **Approval gating** , a human (or policy) must say yes before a risky action
+  runs. Risk is read from the TD (``tc:requiresApproval`` / ``@type
+  tc:Destructive``) and/or from a policy ("any non-idempotent write", "all").
+- **Grounding** , ``verify()`` checks a TD against the *live* Thing (its
+  readable properties actually read, and match their declared types) so you do
+  not trust a description that no longer matches reality.
+
+Both are opt-in and have no LLM dependency.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, Literal
+
+if TYPE_CHECKING:
+    from thingctx.thing import WoTAction
+
+# When to ask the approver before an action runs:
+#   declared    , only actions the TD marks risky (tc:requiresApproval/Destructive)
+#   destructive , the above plus any non-idempotent (non-safe) action
+#   all         , every action (and every property write)
+#   never       , gating off
+ApprovePolicy = Literal["declared", "destructive", "all", "never"]
+
+
+@dataclass
+class ApprovalRequest:
+    """What the approver is asked to allow. Returned truthy = proceed."""
+
+    tool_name: str
+    arguments: dict[str, Any]
+    thing_id: str
+    action_name: str
+    reason: str
+    description: str = ""
+
+
+# An approver allows or denies a gated call. Sync or async; truthy = allow.
+Approver = Callable[[ApprovalRequest], "bool | Awaitable[bool]"]
+
+
+def _action_reason(action: WoTAction, policy: ApprovePolicy) -> str | None:
+    """Reason this action needs approval under ``policy``, or None to proceed."""
+    if policy == "never":
+        return None
+    if policy == "all":
+        return "policy=all"
+    if action.requires_approval():
+        return "TD-declared (tc:requiresApproval / tc:Destructive)"
+    if policy == "destructive" and action.is_destructive():
+        return "non-idempotent action"
+    return None
+
+
+async def _ask(approve: Approver | None, req: ApprovalRequest) -> dict[str, Any] | None:
+    """Run the approver. Returns an error envelope to block, or None to allow.
+
+    No approver wired but approval is required = deny (the safe default): a gate
+    with nobody to open it stays shut."""
+    if approve is None:
+        return {
+            "error": "approval required but no approver configured",
+            "tool": req.tool_name,
+            "reason": req.reason,
+            "hint": "pass approve=<callable> to ThingClient, or approve_when='never' to disable",
+        }
+    verdict = approve(req)
+    if inspect.isawaitable(verdict):
+        verdict = await verdict
+    if not verdict:
+        return {"error": "approval denied", "tool": req.tool_name, "reason": req.reason}
+    return None
+
+
+async def gate_action(
+    action: WoTAction,
+    tool_name: str,
+    arguments: dict[str, Any] | None,
+    *,
+    approve: Approver | None,
+    policy: ApprovePolicy,
+) -> dict[str, Any] | None:
+    """Error envelope if this action call is blocked, else None to proceed."""
+    reason = _action_reason(action, policy)
+    if reason is None:
+        return None
+    return await _ask(
+        approve,
+        ApprovalRequest(
+            tool_name=tool_name,
+            arguments=dict(arguments or {}),
+            thing_id=action.thing_id,
+            action_name=action.name,
+            reason=reason,
+            description=action.description,
+        ),
+    )
+
+
+async def gate_write(
+    thing_id: str,
+    name: str,
+    value: Any,
+    *,
+    approve: Approver | None,
+    policy: ApprovePolicy,
+) -> dict[str, Any] | None:
+    """A property write is a state mutation; gate it under destructive/all."""
+    if policy not in ("destructive", "all"):
+        return None
+    return await _ask(
+        approve,
+        ApprovalRequest(
+            tool_name=name,
+            arguments={"value": value},
+            thing_id=thing_id,
+            action_name=f"write {name}",
+            reason="property write (state mutation)",
+        ),
+    )
+
+
+# --- grounding: verify a TD against the live Thing -------------------------
+
+_JSON_TYPES: dict[str, tuple[type, ...]] = {
+    "integer": (int,),
+    "number": (int, float),
+    "string": (str,),
+    "boolean": (bool,),
+    "object": (dict,),
+    "array": (list,),
+}
+
+
+@dataclass
+class Check:
+    """One grounding check and its outcome."""
+
+    target: str
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class VerifyReport:
+    """Result of grounding a Thing's TD against its live endpoint."""
+
+    thing_id: str
+    ok: bool
+    checks: list[Check] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "thing": self.thing_id,
+            "ok": self.ok,
+            "checks": [{"target": c.target, "ok": c.ok, "detail": c.detail} for c in self.checks],
+        }
+
+
+def _type_ok(schema: dict[str, Any], value: Any) -> tuple[bool, str]:
+    """Lenient type check: only fails on a clear scalar-type mismatch."""
+    # Binary/media payloads (e.g. an image property) are not JSON-typed; a
+    # successful read is the signal, so never flag bytes as a type mismatch.
+    if isinstance(value, (bytes, bytearray)):
+        return True, ""
+    declared = schema.get("type") if isinstance(schema, dict) else None
+    if not declared or declared not in _JSON_TYPES:
+        return True, ""
+    expected = _JSON_TYPES[declared]
+    # bool is an int in Python; keep them distinct for declared types.
+    if declared != "boolean" and isinstance(value, bool):
+        return False, f"declared {declared}, got boolean"
+    if isinstance(value, expected):
+        return True, ""
+    return False, f"declared {declared}, got {type(value).__name__}"
+
+
+async def verify_thing(client: Any, thing: Any) -> VerifyReport:
+    """Ground one Thing: read each readable property and check it answers and
+    matches its declared scalar type. Actions are listed but never invoked
+    (invoking has side effects), so grounding stays read-only and safe."""
+    from thingctx.thing import _tool_name
+
+    checks: list[Check] = []
+    for prop in thing.properties.values():
+        if not prop.readable:
+            continue
+        target = f"property:{prop.name}"
+        name = _tool_name(thing.id, prop.name)
+        try:
+            value = await client.read_property(name)
+        except Exception as exc:  # a live transport can raise; record, don't crash
+            checks.append(Check(target, False, f"read raised {type(exc).__name__}: {exc}"))
+            continue
+        if isinstance(value, dict) and "error" in value:
+            checks.append(Check(target, False, str(value["error"])))
+            continue
+        type_ok, detail = _type_ok(prop.schema, value)
+        checks.append(Check(target, type_ok, detail or "read ok"))
+    if not checks:
+        checks.append(Check("properties", True, "no readable properties to ground"))
+    return VerifyReport(thing.id, ok=all(c.ok for c in checks), checks=checks)

--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -79,9 +79,10 @@ async def test_safe_action_not_gated():
 
 @pytest.mark.asyncio
 async def test_destructive_policy_gates_non_idempotent():
-    assert "approval required" in (await _client(approve_when="destructive").invoke("pump.drain"))[
-        "error"
-    ]
+    assert (
+        "approval required"
+        in (await _client(approve_when="destructive").invoke("pump.drain"))["error"]
+    )
     ok = await _client(approve_when="destructive", approve=lambda req: True).invoke("pump.drain")
     assert ok == {"drained": True}
 
@@ -123,8 +124,12 @@ async def test_verify_ok():
 
 @pytest.mark.asyncio
 async def test_verify_detects_type_mismatch():
-    bad = {**TD, "properties": {"rpm": {"type": "string", "readOnly": True,
-                                         "forms": [{"href": "local://rpm"}]}}}
+    bad = {
+        **TD,
+        "properties": {
+            "rpm": {"type": "string", "readOnly": True, "forms": [{"href": "local://rpm"}]}
+        },
+    }
     # device returns int 1200, TD now declares string -> mismatch
     client = ThingClient(tds=[bad], invokers=[LocalInvoker(Pump())])
     report = (await client.verify())[0]
@@ -134,8 +139,12 @@ async def test_verify_detects_type_mismatch():
 
 @pytest.mark.asyncio
 async def test_verify_detects_unreadable_property():
-    bad = {**TD, "properties": {"ghost": {"type": "integer", "readOnly": True,
-                                          "forms": [{"href": "local://ghost"}]}}}
+    bad = {
+        **TD,
+        "properties": {
+            "ghost": {"type": "integer", "readOnly": True, "forms": [{"href": "local://ghost"}]}
+        },
+    }
     client = ThingClient(tds=[bad], invokers=[LocalInvoker(Pump())])  # no 'ghost' on device
     report = (await client.verify())[0]
     assert not report.ok
@@ -144,9 +153,17 @@ async def test_verify_detects_unreadable_property():
 @pytest.mark.asyncio
 async def test_verify_does_not_flag_binary_media():
     # an image property reads as bytes; declared "string" must NOT be drift
-    td = {**TD, "properties": {"frame": {"type": "string", "readOnly": True,
-                                         "contentMediaType": "image/png",
-                                         "forms": [{"href": "local://frame"}]}}}
+    td = {
+        **TD,
+        "properties": {
+            "frame": {
+                "type": "string",
+                "readOnly": True,
+                "contentMediaType": "image/png",
+                "forms": [{"href": "local://frame"}],
+            }
+        },
+    }
     inv = LocalInvoker({"frame": lambda: b"\x89PNG\r\n"})
     report = (await ThingClient(tds=[td], invokers=[inv]).verify())[0]
     assert report.ok, report.as_dict()

--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -1,0 +1,152 @@
+"""Trust layer: approval gating + verify() grounding, over LocalInvoker."""
+
+from __future__ import annotations
+
+import pytest
+
+from thingctx import LocalInvoker, ThingClient
+
+TD = {
+    "@context": "https://www.w3.org/2022/wot/td/v1.1",
+    "id": "urn:demo:pump:v1",
+    "title": "Pump",
+    "securityDefinitions": {"nosec_sc": {"scheme": "nosec"}},
+    "security": ["nosec_sc"],
+    "properties": {
+        "rpm": {"type": "integer", "readOnly": True, "forms": [{"href": "local://rpm"}]},
+        "target_rpm": {"type": "integer", "forms": [{"href": "local://target_rpm"}]},
+    },
+    "actions": {
+        "set_speed": {  # safe (idempotent), not gated under "declared"
+            "idempotent": True,
+            "input": {"type": "object", "properties": {"rpm": {"type": "integer"}}},
+            "forms": [{"href": "local://set_speed"}],
+        },
+        "estop": {  # TD-declared destructive
+            "@type": "tc:Destructive",
+            "forms": [{"href": "local://estop"}],
+        },
+        "drain": {"forms": [{"href": "local://drain"}]},  # non-idempotent, undeclared
+    },
+}
+
+
+class Pump:
+    def __init__(self):
+        self.rpm = 1200
+        self.target_rpm = 0
+
+    def set_speed(self, rpm=0):
+        return {"ok": True, "rpm": rpm}
+
+    def estop(self):
+        return {"stopped": True}
+
+    def drain(self):
+        return {"drained": True}
+
+
+def _client(**kw):
+    return ThingClient(tds=[TD], invokers=[LocalInvoker(Pump())], **kw)
+
+
+@pytest.mark.asyncio
+async def test_declared_destructive_blocked_without_approver():
+    res = await _client().invoke("pump.estop")  # default approve_when="declared"
+    assert "approval required" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_declared_destructive_allowed_when_approved():
+    res = await _client(approve=lambda req: True).invoke("pump.estop")
+    assert res == {"stopped": True}
+
+
+@pytest.mark.asyncio
+async def test_declared_destructive_denied():
+    res = await _client(approve=lambda req: False).invoke("pump.estop")
+    assert res["error"] == "approval denied"
+
+
+@pytest.mark.asyncio
+async def test_safe_action_not_gated():
+    seen = []
+    client = _client(approve=lambda req: seen.append(req) or True)
+    res = await client.invoke("pump.set_speed", {"rpm": 900})
+    assert res == {"ok": True, "rpm": 900}
+    assert seen == []  # approver never consulted for a safe action
+
+
+@pytest.mark.asyncio
+async def test_destructive_policy_gates_non_idempotent():
+    assert "approval required" in (await _client(approve_when="destructive").invoke("pump.drain"))[
+        "error"
+    ]
+    ok = await _client(approve_when="destructive", approve=lambda req: True).invoke("pump.drain")
+    assert ok == {"drained": True}
+
+
+@pytest.mark.asyncio
+async def test_all_policy_gates_even_safe_action():
+    seen = []
+    client = _client(approve_when="all", approve=lambda req: seen.append(req.tool_name) or True)
+    await client.invoke("pump.set_speed", {"rpm": 900})
+    assert seen == ["pump.set_speed"]
+
+
+@pytest.mark.asyncio
+async def test_never_policy_disables_gate():
+    res = await _client(approve_when="never").invoke("pump.estop")  # no approver, still runs
+    assert res == {"stopped": True}
+
+
+@pytest.mark.asyncio
+async def test_async_approver():
+    async def approve(req):
+        return True
+
+    assert await _client(approve=approve).invoke("pump.estop") == {"stopped": True}
+
+
+@pytest.mark.asyncio
+async def test_property_write_gated_under_all():
+    blocked = await _client(approve_when="all").write_property("pump.target_rpm", 1500)
+    assert "approval required" in blocked["error"]
+
+
+@pytest.mark.asyncio
+async def test_verify_ok():
+    reports = await _client().verify()
+    assert len(reports) == 1
+    assert reports[0].ok, reports[0].as_dict()
+
+
+@pytest.mark.asyncio
+async def test_verify_detects_type_mismatch():
+    bad = {**TD, "properties": {"rpm": {"type": "string", "readOnly": True,
+                                         "forms": [{"href": "local://rpm"}]}}}
+    # device returns int 1200, TD now declares string -> mismatch
+    client = ThingClient(tds=[bad], invokers=[LocalInvoker(Pump())])
+    report = (await client.verify())[0]
+    assert not report.ok
+    assert any("declared string" in c.detail for c in report.checks)
+
+
+@pytest.mark.asyncio
+async def test_verify_detects_unreadable_property():
+    bad = {**TD, "properties": {"ghost": {"type": "integer", "readOnly": True,
+                                          "forms": [{"href": "local://ghost"}]}}}
+    client = ThingClient(tds=[bad], invokers=[LocalInvoker(Pump())])  # no 'ghost' on device
+    report = (await client.verify())[0]
+    assert not report.ok
+
+
+@pytest.mark.asyncio
+async def test_verify_does_not_flag_binary_media():
+    # an image property reads as bytes; declared "string" must NOT be drift
+    td = {**TD, "properties": {"frame": {"type": "string", "readOnly": True,
+                                         "contentMediaType": "image/png",
+                                         "forms": [{"href": "local://frame"}]}}}
+    inv = LocalInvoker({"frame": lambda: b"\x89PNG\r\n"})
+    report = (await ThingClient(tds=[td], invokers=[inv]).verify())[0]
+    assert report.ok, report.as_dict()

--- a/tests/test_trust_mcp.py
+++ b/tests/test_trust_mcp.py
@@ -68,6 +68,18 @@ async def test_mcp_safe_action_not_gated():
 
 
 @pytest.mark.asyncio
+async def test_default_elicit_keeps_existing_approver():
+    pytest.importorskip("mcp")
+    from thingctx.integrations.mcp import build_mcp_server
+
+    own = lambda req: True  # noqa: E731
+    client = ThingClient(tds=[TD], invokers=[_inv()], approve=own)
+    build_mcp_server(client)  # default approve="elicit" must not clobber it
+    assert client._approve is own
+    assert "wiped" in await _call(build_mcp_server(client), "vault.wipe")
+
+
+@pytest.mark.asyncio
 async def test_elicit_approver_accept_deny_and_fallback():
     pytest.importorskip("mcp")
     from thingctx.integrations.mcp import _elicit_approver

--- a/tests/test_trust_mcp.py
+++ b/tests/test_trust_mcp.py
@@ -1,0 +1,99 @@
+"""The trust gate holds over the MCP bridge (the Claude/Copilot CLI path):
+call_tool routes through ThingClient.invoke, so risky tools are gated there
+too. Plus a unit check of the elicitation approver's accept/deny/fallback."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from thingctx import LocalInvoker, ThingClient
+
+TD = {
+    "@context": ["https://www.w3.org/2022/wot/td/v1.1", {"tc": "https://thingctx.dev/vocab#"}],
+    "id": "urn:demo:vault:v1",
+    "title": "Vault",
+    "securityDefinitions": {"nosec_sc": {"scheme": "nosec"}},
+    "security": ["nosec_sc"],
+    "actions": {
+        "status": {"idempotent": True, "forms": [{"href": "local://status"}]},
+        "wipe": {"@type": "tc:Destructive", "forms": [{"href": "local://wipe"}]},
+    },
+}
+
+
+def _inv():
+    return LocalInvoker({"status": lambda: {"ok": True}, "wipe": lambda: {"wiped": True}})
+
+
+async def _call(server, tool, args=None):
+    from mcp.shared.memory import create_connected_server_and_client_session as connect
+
+    async with connect(server) as s:
+        await s.initialize()
+        res = await s.call_tool(tool, args or {})
+        return res.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_mcp_blocks_declared_destructive_when_denied():
+    pytest.importorskip("mcp")
+    from thingctx.integrations.mcp import build_mcp_server
+
+    server = build_mcp_server(ThingClient(tds=[TD], invokers=[_inv()]), approve=lambda req: False)
+    assert "approval denied" in await _call(server, "vault.wipe")
+
+
+@pytest.mark.asyncio
+async def test_mcp_allows_declared_destructive_when_approved():
+    pytest.importorskip("mcp")
+    from thingctx.integrations.mcp import build_mcp_server
+
+    server = build_mcp_server(ThingClient(tds=[TD], invokers=[_inv()]), approve=lambda req: True)
+    assert "wiped" in await _call(server, "vault.wipe")
+
+
+@pytest.mark.asyncio
+async def test_mcp_safe_action_not_gated():
+    pytest.importorskip("mcp")
+    from thingctx.integrations.mcp import build_mcp_server
+
+    seen = []
+    server = build_mcp_server(
+        ThingClient(tds=[TD], invokers=[_inv()]), approve=lambda req: seen.append(1) or False
+    )
+    assert "ok" in await _call(server, "vault.status")  # idempotent -> never gated
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_elicit_approver_accept_deny_and_fallback():
+    pytest.importorskip("mcp")
+    from thingctx.integrations.mcp import _elicit_approver
+    from thingctx.trust import ApprovalRequest
+
+    req = ApprovalRequest("vault.wipe", {}, "urn:demo:vault:v1", "wipe", "TD-declared")
+
+    def server_with(action=None, raise_elicit=False, no_ctx=False):
+        async def elicit(message, requestedSchema):
+            if raise_elicit:
+                raise RuntimeError("client has no elicitation capability")
+            return SimpleNamespace(action=action)
+
+        session = SimpleNamespace(elicit=elicit)
+
+        class S:
+            @property
+            def request_context(self):
+                if no_ctx:
+                    raise LookupError("no active request")
+                return SimpleNamespace(session=session)
+
+        return S()
+
+    assert await _elicit_approver(server_with(action="accept"))(req) is True
+    assert await _elicit_approver(server_with(action="decline"))(req) is False
+    assert await _elicit_approver(server_with(action="cancel"))(req) is False
+    assert await _elicit_approver(server_with(raise_elicit=True))(req) is False
+    assert await _elicit_approver(server_with(no_ctx=True))(req) is False


### PR DESCRIPTION
Opt-in approval gating for risky actions + `verify_thing()` grounding against the live device. No LLM dependency. Docs, example, tests.