### PR TITLE
feat: reliable invokers (retries + reconnect)

### DIFF
--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -66,6 +66,7 @@ from thingctx.registry import (
     from_arg,
     from_args,
 )
+from thingctx.reliability import RetryPolicy, TransportError
 from thingctx.runtime import ThingClient
 from thingctx.thing import (
     WoTAction,
@@ -141,4 +142,6 @@ __all__ = [
     "ApprovalRequest",
     "VerifyReport",
     "Check",
+    "RetryPolicy",
+    "TransportError",
 ]

--- a/src/thingctx/invokers/http.py
+++ b/src/thingctx/invokers/http.py
@@ -14,6 +14,12 @@ class HttpInvoker(_AuthBinding):
     :class:`_AuthBinding`) and maps it onto the request with ``apply_http`` --
     headers, query params, a client certificate, or request signing. No auth
     logic lives in this transport.
+
+    Transient failures (connection errors, timeouts, 429, 5xx) are retried with
+    bounded exponential backoff, and any non-2xx outcome surfaces as a single
+    ``TransportError``. Retries are gated to idempotent methods unless
+    ``retry_non_idempotent`` is set, so a write is never silently re-sent. A
+    pooled client is reused across calls to keep connections warm.
     """
 
     scheme = "http"
@@ -27,7 +33,12 @@ class HttpInvoker(_AuthBinding):
         allow_insecure_oauth: bool = False,
         auth: AuthRegistry | None = None,
         extra_auth: list[AuthStrategy] | None = None,
+        retries: int = 2,
+        backoff: float = 0.2,
+        retry_non_idempotent: bool = False,
     ) -> None:
+        from thingctx.reliability import RetryPolicy
+
         self._headers = headers or {}
         self._init_auth(
             credentials=credentials,
@@ -36,6 +47,11 @@ class HttpInvoker(_AuthBinding):
             timeout=timeout,
             allow_insecure_oauth=allow_insecure_oauth,
         )
+        self._retry_non_idempotent = retry_non_idempotent
+        self._policy = RetryPolicy(retries=retries, backoff=backoff)
+        # One pooled AsyncClient, created lazily inside the running loop and
+        # reused across calls so connections (and TLS handshakes) stay warm.
+        self._client = None
         # This invoker also claims https.
         self.schemes = ("http", "https")
 
@@ -60,9 +76,80 @@ class HttpInvoker(_AuthBinding):
             if inspect.isawaitable(result):
                 await result
 
-    async def invoke(self, action, form, arguments):  # noqa: ANN001
+    def _pool(self):
+        """The lazily-created, reused client (created inside the running loop so
+        it binds to the right event loop; recreated if closed)."""
         import httpx
 
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the pooled client and its connections. Safe to call twice."""
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+        self._client = None
+
+    async def __aenter__(self) -> HttpInvoker:
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        await self.aclose()
+
+    async def _send(self, method, url, *, signers, cert, empty=None, **kwargs):
+        """Build, sign, and send a request with retries, then normalize the
+        outcome: a non-2xx becomes a ``TransportError`` (the same shape a
+        transport-level failure raises), and the body is decoded by content
+        type. A request is rebuilt and re-signed on each attempt.
+
+        The pooled client serves the common case; when a per-owner client
+        certificate is present a short-lived client is used instead, since mTLS
+        is owner-specific and cannot share the pool."""
+        import asyncio
+
+        import httpx
+
+        from thingctx.reliability import (
+            IDEMPOTENT_METHODS,
+            TransportError,
+            _retry_after,
+        )
+
+        retryable = method.upper() in IDEMPOTENT_METHODS or self._retry_non_idempotent
+        max_retries = self._policy.retries if retryable else 0
+        pooled = cert is None
+        client = self._pool() if pooled else httpx.AsyncClient(timeout=self._timeout, cert=cert)
+        try:
+            for attempt in range(max_retries + 1):
+                req = client.build_request(method, url, **kwargs)
+                await self._sign_request(signers, req)
+                try:
+                    resp = await client.send(req)
+                except httpx.TransportError as exc:  # connection + timeout errors
+                    if attempt < max_retries:
+                        await asyncio.sleep(self._policy.delay(attempt))
+                        continue
+                    raise TransportError(method, url, attempts=attempt + 1, cause=exc) from exc
+                if resp.status_code in self._policy.retry_statuses and attempt < max_retries:
+                    await asyncio.sleep(_retry_after(resp, self._policy, attempt))
+                    continue
+                if resp.is_error:
+                    detail = ""
+                    try:
+                        detail = resp.text[:200]
+                    except Exception:  # noqa: BLE001 - detail is best-effort
+                        pass
+                    raise TransportError(
+                        method, url, status=resp.status_code, attempts=attempt + 1, detail=detail
+                    )
+                return _decode(resp, empty=empty)
+            raise AssertionError("unreachable")  # pragma: no cover
+        finally:
+            if not pooled:
+                await client.aclose()
+
+    async def invoke(self, action, form, arguments):  # noqa: ANN001
         headers, params, signers, cert = await self._prepare(getattr(action, "thing_id", None))
         # HTTP binding: honor the form's declared method, else default by
         # safety. Idempotent (safe) actions GET with args as query params;
@@ -70,44 +157,46 @@ class HttpInvoker(_AuthBinding):
         method = form.raw.get("htv:methodName")
         if method is None:
             method = "GET" if getattr(action, "idempotent", False) else "POST"
-        async with httpx.AsyncClient(timeout=self._timeout, cert=cert) as client:
-            if method.upper() == "GET":
-                req = client.build_request(
-                    "GET", form.href, headers=headers, params={**params, **arguments}
-                )
-            else:
-                req = client.build_request(
-                    method, form.href, json=arguments, headers=headers, params=params
-                )
-            await self._sign_request(signers, req)
-            resp = await client.send(req)
-            resp.raise_for_status()
-            return _decode(resp)
+        if method.upper() == "GET":
+            return await self._send(
+                "GET",
+                form.href,
+                signers=signers,
+                cert=cert,
+                headers=headers,
+                params={**params, **arguments},
+            )
+        return await self._send(
+            method,
+            form.href,
+            signers=signers,
+            cert=cert,
+            headers=headers,
+            params=params,
+            json=arguments,
+        )
 
     async def read(self, prop, form):  # noqa: ANN001
         """GET the property's current value from its form URL."""
-        import httpx
-
         headers, params, signers, cert = await self._prepare(getattr(prop, "thing_id", None))
-        async with httpx.AsyncClient(timeout=self._timeout, cert=cert) as client:
-            req = client.build_request("GET", form.href, headers=headers, params=params)
-            await self._sign_request(signers, req)
-            resp = await client.send(req)
-            resp.raise_for_status()
-            return _decode(resp)
+        return await self._send(
+            "GET", form.href, signers=signers, cert=cert, headers=headers, params=params
+        )
 
     async def write(self, prop, form, value):  # noqa: ANN001
         """PUT the new value to the property's form URL (the ``writeproperty``
         HTTP binding default)."""
-        import httpx
-
         headers, params, signers, cert = await self._prepare(getattr(prop, "thing_id", None))
-        async with httpx.AsyncClient(timeout=self._timeout, cert=cert) as client:
-            req = client.build_request("PUT", form.href, json=value, headers=headers, params=params)
-            await self._sign_request(signers, req)
-            resp = await client.send(req)
-            resp.raise_for_status()
-            return _decode(resp, empty={"ok": True})
+        return await self._send(
+            "PUT",
+            form.href,
+            signers=signers,
+            cert=cert,
+            headers=headers,
+            params=params,
+            json=value,
+            empty={"ok": True},
+        )
 
     async def subscribe(self, name, form):  # noqa: ANN001
         """Subscribe over Server-Sent Events (the HTTP streaming binding for

--- a/src/thingctx/invokers/mqtt.py
+++ b/src/thingctx/invokers/mqtt.py
@@ -8,18 +8,44 @@ from thingctx.auth import AuthRegistry, AuthStrategy, apply_mqtt
 from thingctx.invokers.base import _AuthBinding
 
 
+def _decode_mqtt(payload):
+    """Decode an MQTT payload: JSON to a value, else a best-effort string."""
+    try:
+        return json.loads(payload.decode())
+    except Exception:  # noqa: BLE001 - non-JSON payloads fall back to text
+        try:
+            return payload.decode(errors="replace")
+        except Exception:  # noqa: BLE001
+            return payload
+
+
+def _connack_ok(rc) -> bool:
+    """True if a CONNACK reason code means success, across paho v1 (int 0) and
+    v2 (a ReasonCode whose ``value`` is 0)."""
+    if rc == 0:
+        return True
+    return getattr(rc, "value", None) == 0
+
+
 class MqttInvoker(_AuthBinding):
     """Publish the action input to the form's mqtt topic, await a reply.
 
     Built on ``paho-mqtt``. The form's ``href`` is ``mqtt://broker[:port]/<topic>``;
-    the reply is awaited on ``<topic>/reply``.
+    a request/reply ``invoke`` awaits the reply on ``<topic>/reply``.
 
     Authentication is the *same* transport-neutral layer the HTTP invoker uses:
     bind resources with ``with_security``/``with_things`` and pass
     ``credentials``; the shared primitive resolves them into neutral material and
-    ``apply_mqtt`` maps it onto the CONNECT (username/password, mutual TLS, or
-    v5 enhanced auth). A username/password scheme becomes username/password; a
-    token becomes the password (token-as-password).
+    ``apply_mqtt`` maps it onto the CONNECT (username/password, mutual TLS, or v5
+    enhanced auth). A username/password scheme becomes username/password; a token
+    becomes the password (token-as-password).
+
+    Reliability is built in: the connect is retried with backoff,
+    publishes/subscribes use QoS 1 by default, the subscription is
+    **re-established on every reconnect** (paho does not resubscribe for you),
+    and connect/reply failures surface as the same ``TransportError`` the HTTP
+    invoker raises. Pass ``client_factory`` to supply your own configured client
+    (or a fake, in tests).
     """
 
     scheme = "mqtt"
@@ -33,7 +59,16 @@ class MqttInvoker(_AuthBinding):
         allow_insecure_oauth: bool = False,
         auth: AuthRegistry | None = None,
         extra_auth: list[AuthStrategy] | None = None,
+        qos: int = 1,
+        client_id: str | None = None,
+        clean_session: bool | None = None,
+        connect_retries: int = 3,
+        backoff: float = 0.2,
+        connect_timeout: float = 10.0,
+        client_factory=None,
     ) -> None:
+        from thingctx.reliability import RetryPolicy
+
         self._broker = broker
         self._init_auth(
             credentials=credentials,
@@ -42,19 +77,35 @@ class MqttInvoker(_AuthBinding):
             timeout=timeout,
             allow_insecure_oauth=allow_insecure_oauth,
         )
+        self._qos = qos
+        self._client_id = client_id
+        # A persistent session (clean_session=False) lets the broker queue QoS-1
+        # messages while disconnected, but needs a stable client id. Default:
+        # persistent when an id is given, clean otherwise.
+        self._clean_session = (client_id is None) if clean_session is None else clean_session
+        self._connect_timeout = connect_timeout
+        self._client_factory = client_factory
+        self._connect_policy = RetryPolicy(retries=connect_retries, backoff=backoff)
 
-    @staticmethod
-    def _new_client(enhanced: bool = False):
+    def _new_client(self, enhanced: bool = False):
         """A paho client that works across paho-mqtt 1.x and 2.x (2.x requires
         an explicit callback API version). Uses MQTT v5 when ``enhanced`` auth
         is in play, since enhanced authentication is a v5 feature."""
+        if self._client_factory is not None:
+            return self._client_factory()
         import paho.mqtt.client as mqtt  # type: ignore
 
-        kwargs = {"protocol": mqtt.MQTTv5} if enhanced else {}
+        cid = self._client_id or ""
         version = getattr(mqtt, "CallbackAPIVersion", None)
-        if version is not None:  # paho-mqtt >= 2.0
-            return mqtt.Client(version.VERSION1, **kwargs)
-        return mqtt.Client(**kwargs)
+        args = (version.VERSION1,) if version is not None else ()  # paho-mqtt >= 2.0
+        if enhanced:
+            # MQTT v5 has no clean_session (it uses a per-connect clean_start).
+            client = mqtt.Client(*args, client_id=cid, protocol=mqtt.MQTTv5)
+        else:
+            client = mqtt.Client(*args, client_id=cid, clean_session=self._clean_session)
+        # Bound the reconnect backoff paho applies when a live connection drops.
+        client.reconnect_delay_set(min_delay=1, max_delay=30)
+        return client
 
     @staticmethod
     def _configure_client(client, plan) -> None:
@@ -74,8 +125,7 @@ class MqttInvoker(_AuthBinding):
     @staticmethod
     def _connect_properties(plan):
         """The MQTT v5 CONNECT properties carrying enhanced authentication
-        (``AuthenticationMethod`` + ``AuthenticationData``), or ``None``. The
-        method names the mechanism; the data is the initial token/challenge."""
+        (``AuthenticationMethod`` + ``AuthenticationData``), or ``None``."""
         if plan.enhanced is None:
             return None
         from paho.mqtt.packettypes import PacketTypes  # type: ignore
@@ -87,6 +137,15 @@ class MqttInvoker(_AuthBinding):
             props.AuthenticationData = plan.enhanced.data.get_secret_bytes()
         return props
 
+    def _endpoint(self, form, fallback: str):
+        import urllib.parse
+
+        u = urllib.parse.urlparse(form.href)
+        host = self._broker or u.hostname or "localhost"
+        port = u.port or 1883
+        topic = u.path.lstrip("/") or fallback
+        return host, port, topic
+
     async def _apply_auth(self, client, owner_id: str | None):
         """Configure an existing client's connection auth from the owner's
         credentials. Returns the ``MqttAuthPlan`` for inspection/testing."""
@@ -95,84 +154,127 @@ class MqttInvoker(_AuthBinding):
         return plan
 
     async def _connect(self, owner_id: str | None, host: str, port: int):
-        """Resolve the owner's credentials, build a client of the right
-        protocol, configure it, and return ``(client, properties)`` ready to
-        connect. All auth comes from the shared, transport-neutral layer."""
+        """Resolve the owner's credentials, build a client of the right protocol,
+        and configure its connection auth. Returns ``(client, properties)`` ready
+        to connect -- all auth comes from the shared, transport-neutral layer."""
         plan = apply_mqtt(await self._resolve_credentials(owner_id))
         client = self._new_client(enhanced=plan.enhanced is not None)
         self._configure_client(client, plan)
         return client, self._connect_properties(plan)
 
+    async def _establish(self, client, host, port, *, topics, props=None):
+        """Connect with retry/backoff and (re)subscribe to ``topics`` on every
+        successful (re)connection, then wait for CONNACK. Raises TransportError
+        if it cannot connect within the retry budget."""
+        import asyncio
+
+        from thingctx.reliability import TransportError
+
+        loop = asyncio.get_running_loop()
+        policy = self._connect_policy
+        connect_kwargs = {"properties": props} if props else {}
+        for attempt in range(policy.retries + 1):
+            # A fresh event per attempt so a late CONNACK from a previous,
+            # abandoned attempt can never satisfy this one's wait.
+            connected = asyncio.Event()
+
+            def _on_connect(_c, _u, _flags, rc, *_args, _ev=connected):  # paho v1+v2
+                if _connack_ok(rc):
+                    # paho does not resubscribe after a reconnect; do it here so a
+                    # dropped connection transparently restores the subscription.
+                    for t in topics:
+                        client.subscribe(t, qos=self._qos)
+                    loop.call_soon_threadsafe(_ev.set)
+
+            client.on_connect = _on_connect
+            try:
+                client.connect(host, port, **connect_kwargs)
+                client.loop_start()
+                await asyncio.wait_for(connected.wait(), timeout=self._connect_timeout)
+                return
+            except Exception as exc:  # noqa: BLE001 - normalize every connect failure
+                # Tear the attempt down fully (stop the loop and close the socket)
+                # before retrying or giving up, so no connection leaks.
+                self._shutdown(client)
+                if attempt < policy.retries:
+                    await asyncio.sleep(policy.delay(attempt))
+                    continue
+                raise TransportError(
+                    "CONNECT", f"mqtt://{host}:{port}", attempts=attempt + 1, cause=exc
+                ) from exc
+
+    @staticmethod
+    def _shutdown(client) -> None:
+        for step in ("loop_stop", "disconnect"):
+            try:
+                getattr(client, step)()
+            except Exception:  # noqa: BLE001 - shutdown is best-effort
+                pass
+
     async def invoke(self, action, form, arguments):  # noqa: ANN001
         import asyncio
-        import urllib.parse
 
-        u = urllib.parse.urlparse(form.href)
-        host = self._broker or u.hostname or "localhost"
-        port = u.port or 1883
-        topic = u.path.lstrip("/") or action.name
+        from thingctx.reliability import TransportError
+
+        host, port, topic = self._endpoint(form, getattr(action, "name", "action"))
         reply_topic = f"{topic}/reply"
-
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         fut: asyncio.Future = loop.create_future()
-
         client, props = await self._connect(getattr(action, "thing_id", None), host, port)
 
         def _on_message(_c, _u, msg):  # noqa: ANN001
-            try:
-                payload = json.loads(msg.payload.decode())
-            except Exception:  # noqa: BLE001
-                payload = msg.payload.decode(errors="replace")
+            payload = _decode_mqtt(msg.payload)
             if not fut.done():
                 loop.call_soon_threadsafe(fut.set_result, payload)
 
         client.on_message = _on_message
-        client.connect(host, port, **({"properties": props} if props else {}))
-        client.subscribe(reply_topic)
-        client.loop_start()
         try:
-            client.publish(topic, json.dumps(arguments))
+            await self._establish(client, host, port, topics=[reply_topic], props=props)
+            info = client.publish(topic, json.dumps(arguments), qos=self._qos)
+            # At QoS >= 1, confirm the broker stored the publish (PUBACK) before
+            # waiting on a reply, so a dropped publish is not mistaken for a slow
+            # device. wait_for_publish blocks, so run it off the event loop.
+            wait_pub = getattr(info, "wait_for_publish", None)
+            if self._qos and callable(wait_pub):
+                await loop.run_in_executor(None, lambda: wait_pub(self._timeout))
             return await asyncio.wait_for(fut, timeout=self._timeout)
-        except asyncio.TimeoutError:
-            return {"error": f"mqtt reply timeout on {reply_topic}"}
+        except asyncio.TimeoutError as exc:
+            raise TransportError(
+                "PUBLISH",
+                f"mqtt://{host}:{port}/{topic}",
+                detail=f"no reply on {reply_topic} within {self._timeout}s",
+                cause=exc,
+            ) from exc
         finally:
-            client.loop_stop()
-            client.disconnect()
+            self._shutdown(client)
 
     async def subscribe(self, name, form):  # noqa: ANN001
         """Subscribe to the form's MQTT topic; yield each message. This is the
-        events / observable-property binding for MQTT: a long-lived
-        subscription, not a request/reply."""
+        events / observable-property binding for MQTT: a long-lived subscription
+        that survives broker reconnects (the topic is re-subscribed on every
+        reconnect)."""
         import asyncio
-        import urllib.parse
 
-        u = urllib.parse.urlparse(form.href)
-        host = self._broker or u.hostname or "localhost"
-        port = u.port or 1883
-        topic = u.path.lstrip("/") or name
-
-        loop = asyncio.get_event_loop()
+        host, port, topic = self._endpoint(form, name)
         queue: asyncio.Queue = asyncio.Queue()
+        loop = asyncio.get_running_loop()
         client, props = await self._connect(getattr(form, "thing_id", None), host, port)
 
         def _on_message(_c, _u, msg):  # noqa: ANN001
-            try:
-                payload = json.loads(msg.payload.decode())
-            except Exception:  # noqa: BLE001
-                payload = msg.payload.decode(errors="replace")
-            loop.call_soon_threadsafe(queue.put_nowait, payload)
+            loop.call_soon_threadsafe(queue.put_nowait, _decode_mqtt(msg.payload))
 
         client.on_message = _on_message
-        client.connect(host, port, **({"properties": props} if props else {}))
-        client.subscribe(topic)
-        client.loop_start()
+        try:
+            await self._establish(client, host, port, topics=[topic], props=props)
+        except BaseException:
+            self._shutdown(client)
+            raise
 
         async def _stream():
             try:
                 while True:
                     yield await queue.get()
             finally:
-                client.loop_stop()
-                client.disconnect()
+                self._shutdown(client)
 
         return _stream()

--- a/src/thingctx/reliability.py
+++ b/src/thingctx/reliability.py
@@ -1,0 +1,118 @@
+"""Cheap reliability for HTTP invokers: bounded retries with exponential
+backoff and jitter, plus one normalized error shape.
+
+A flaky network or a momentarily overloaded device should not surface as a
+raw, transport-specific exception. ``send_with_retry`` retries the transient
+failures (connection errors, timeouts, 429, 5xx) a small number of times, then
+raises a single ``TransportError`` carrying the method, URL, status, and how
+many attempts were made.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass
+
+# Transient HTTP statuses worth retrying: request timeout, rate limit, and the
+# server-side 5xx family that commonly clears on a second try.
+DEFAULT_RETRY_STATUSES: tuple[int, ...] = (408, 429, 500, 502, 503, 504)
+
+# Methods that are safe to auto-retry: re-sending them cannot change server
+# state beyond a single application. POST/PATCH are excluded by default because
+# a retry could double-submit a side effect.
+IDEMPOTENT_METHODS: frozenset[str] = frozenset({"GET", "HEAD", "PUT", "DELETE", "OPTIONS", "TRACE"})
+
+
+@dataclass
+class RetryPolicy:
+    """How many times to retry a transient failure and how long to wait."""
+
+    retries: int = 2  # extra attempts after the first (so up to 3 total)
+    backoff: float = 0.2  # base seconds, doubled each attempt
+    max_backoff: float = 5.0
+    jitter: float = 0.1  # random 0..jitter seconds added, to avoid thundering herd
+    retry_statuses: tuple[int, ...] = DEFAULT_RETRY_STATUSES
+
+    def delay(self, attempt: int) -> float:
+        return min(self.backoff * (2**attempt), self.max_backoff) + random.uniform(0, self.jitter)
+
+
+class TransportError(Exception):
+    """A single error shape for transport failures after retries are spent.
+
+    Carries enough to act on (``status``, ``attempts``) and ``as_dict()`` for
+    callers that prefer to hand the model a structured error rather than raise.
+    """
+
+    def __init__(
+        self,
+        method: str,
+        url: str,
+        *,
+        status: int | None = None,
+        attempts: int = 1,
+        detail: str = "",
+        cause: BaseException | None = None,
+    ) -> None:
+        self.method = method
+        self.url = url
+        self.status = status
+        self.attempts = attempts
+        self.detail = detail
+        where = str(status) if status is not None else (type(cause).__name__ if cause else "error")
+        msg = f"{method} {url} failed after {attempts} attempt(s): {where}"
+        if detail:
+            msg = f"{msg} {detail}"
+        super().__init__(msg.strip())
+        if cause is not None:
+            self.__cause__ = cause
+
+    def as_dict(self) -> dict:
+        return {
+            "ok": False,
+            "error": {
+                "method": self.method,
+                "url": self.url,
+                "status": self.status,
+                "attempts": self.attempts,
+                "detail": self.detail,
+            },
+        }
+
+
+def _retry_after(resp, policy: RetryPolicy, attempt: int) -> float:
+    """Honor a numeric ``Retry-After`` header (429/503) if present and sane,
+    otherwise fall back to the policy's backoff schedule."""
+    if resp is not None:
+        ra = resp.headers.get("retry-after", "")
+        if ra.isdigit():
+            return min(float(ra), policy.max_backoff)
+    return policy.delay(attempt)
+
+
+async def send_with_retry(
+    client, method: str, url: str, *, policy: RetryPolicy, retries: int | None = None, **kwargs
+):
+    """Send a request, retrying transient failures per ``policy``. Returns
+    ``(response, attempts)``; raises ``TransportError`` if every attempt fails
+    at the transport level (the caller decides what to do with a bad status).
+
+    ``retries`` overrides ``policy.retries`` for this call -- the invoker passes
+    ``0`` for non-idempotent methods so a write is never silently re-sent."""
+    import httpx
+
+    max_retries = policy.retries if retries is None else retries
+    for attempt in range(max_retries + 1):
+        try:
+            resp = await client.request(method, url, **kwargs)
+        except httpx.TransportError as exc:  # connection + timeout errors
+            if attempt < max_retries:
+                await asyncio.sleep(policy.delay(attempt))
+                continue
+            raise TransportError(method, url, attempts=attempt + 1, cause=exc) from exc
+        if resp.status_code in policy.retry_statuses and attempt < max_retries:
+            await asyncio.sleep(_retry_after(resp, policy, attempt))
+            continue
+        return resp, attempt + 1
+    raise AssertionError("unreachable")  # pragma: no cover

--- a/src/thingctx/runtime.py
+++ b/src/thingctx/runtime.py
@@ -93,6 +93,20 @@ class ThingClient:
             s for inv in self._invokers for s in (getattr(inv, "schemes", None) or (inv.scheme,))
         )
 
+    async def aclose(self) -> None:
+        """Release any pooled transport resources (e.g. an invoker's reused
+        HTTP client). Safe to call more than once."""
+        for inv in self._invokers:
+            closer = getattr(inv, "aclose", None)
+            if closer is not None:
+                await closer()
+
+    async def __aenter__(self) -> ThingClient:
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        await self.aclose()
+
     def list_actions(self) -> list[dict[str, Any]]:
         """OpenAI-format tool specs for every exposed action."""
         return self._tool_specs

--- a/tests/test_mqtt_live_reliability.py
+++ b/tests/test_mqtt_live_reliability.py
@@ -1,0 +1,121 @@
+"""Live MQTT reliability against a real broker (e.g. a local Mosquitto).
+
+These complement the fake-broker logic tests with a real wire round-trip:
+actual CONNECT/SUBACK/PUBACK, real QoS-1 delivery, and real connection-refused
+handling. They are marked ``network`` (deselect with ``-m 'not network'``) and
+skip automatically if no broker is reachable.
+
+    pytest -m network                 # run them
+    THINGCTX_MQTT_BROKER=host:1883 pytest -m network
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+import time
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from thingctx import TransportError
+from thingctx.invokers import MqttInvoker
+
+pytestmark = pytest.mark.network
+
+BROKER = os.environ.get("THINGCTX_MQTT_BROKER", "localhost:1883")
+HOST, _, _port = BROKER.partition(":")
+PORT = int(_port or "1883")
+
+
+def _reachable(host: str, port: int, timeout: float = 1.0) -> bool:
+    s = socket.socket()
+    s.settimeout(timeout)
+    try:
+        s.connect((host, port))
+        return True
+    except OSError:
+        return False
+    finally:
+        s.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_broker():
+    if not _reachable(HOST, PORT):
+        pytest.skip(f"no MQTT broker reachable at {HOST}:{PORT}")
+
+
+def _mk_paho(cid: str = ""):
+    import paho.mqtt.client as mqtt
+
+    try:
+        return mqtt.Client(client_id=cid)
+    except TypeError:  # paho v2
+        return mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, client_id=cid)
+
+
+def _form(topic: str):
+    action = SimpleNamespace(name="cmd")
+    return action, SimpleNamespace(href=f"mqtt://{HOST}:{PORT}/{topic}", raw={})
+
+
+async def test_live_subscribe_receives_real_publish():
+    topic = f"thingctx/test/{uuid.uuid4().hex}/events"
+    inv = MqttInvoker(qos=1)
+    _action, form = _form(topic)
+
+    stream = await inv.subscribe("evt", form)
+    try:
+        await asyncio.sleep(0.3)  # let the SUBACK settle before publishing
+        pub = _mk_paho()
+        pub.connect(HOST, PORT)
+        pub.loop_start()
+        try:
+            pub.publish(topic, json.dumps({"temp": 98}), qos=1)
+            msg = await asyncio.wait_for(stream.__anext__(), timeout=5.0)
+        finally:
+            pub.loop_stop()
+            pub.disconnect()
+        assert msg == {"temp": 98}
+    finally:
+        await stream.aclose()
+
+
+async def test_live_invoke_round_trip_with_echo_responder():
+    cmd = f"thingctx/test/{uuid.uuid4().hex}/cmd"
+    reply = f"{cmd}/reply"
+
+    # A stand-in device: subscribe to the command topic, echo each payload back
+    # on the reply topic. This is what a real Thing's MQTT side would do.
+    responder = _mk_paho()
+    responder.on_connect = lambda c, u, f, rc, *a: c.subscribe(cmd, qos=1)
+    responder.on_message = lambda c, u, m: c.publish(reply, m.payload, qos=1)
+    responder.connect(HOST, PORT)
+    responder.loop_start()
+    try:
+        time.sleep(0.3)  # responder subscription active before we publish
+        inv = MqttInvoker(qos=1, timeout=5.0)
+        action, form = _form(cmd)
+
+        result = await inv.invoke(action, form, {"rpm": 1234})
+
+        assert result == {"rpm": 1234}
+    finally:
+        responder.loop_stop()
+        responder.disconnect()
+
+
+async def test_live_connection_refused_is_normalized():
+    inv = MqttInvoker(connect_retries=0, connect_timeout=1.0, backoff=0)
+    # A port with nothing listening: a real refused/timed-out connect.
+    action = SimpleNamespace(name="cmd")
+    form = SimpleNamespace(href=f"mqtt://{HOST}:12399/thingctx/test/dead", raw={})
+
+    with pytest.raises(TransportError) as ei:
+        await inv.invoke(action, form, {})
+
+    assert ei.value.method == "CONNECT"

--- a/tests/test_mqtt_reliability.py
+++ b/tests/test_mqtt_reliability.py
@@ -1,0 +1,283 @@
+"""MqttInvoker reliability, tested against a fake broker client (no real
+broker): connect retry/backoff, QoS, re-subscribe on reconnect, reply-timeout
+normalization, and graceful shutdown."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import thingctx.reliability as reliability
+from thingctx import TransportError, parse_thing
+from thingctx.auth import EnhancedAuth
+from thingctx.invokers import MqttInvoker
+
+
+class _Msg:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+
+
+class _Info:
+    rc = 0
+
+    def wait_for_publish(self, timeout=None):  # paho MQTTMessageInfo shape
+        return None
+
+
+class FakeClient:
+    """Mimics the slice of paho's API the invoker uses. ``loop_start`` fires
+    ``on_connect`` (a simulated CONNACK); ``publish`` optionally delivers a
+    reply via ``on_message`` to complete a request/reply call."""
+
+    def __init__(self, *, fail_connects: int = 0, auto_reply=None):
+        self.fail_connects = fail_connects
+        self.auto_reply = auto_reply
+        self.subscriptions: list[tuple[str, int]] = []
+        self.publishes: list[tuple[str, str, int]] = []
+        self.connect_calls = 0
+        self.loop_stopped = False
+        self.disconnected = False
+        self.on_connect = None
+        self.on_message = None
+
+    def reconnect_delay_set(self, **kw):
+        pass
+
+    def connect(self, host, port):
+        self.connect_calls += 1
+        self.host, self.port = host, port
+        if self.fail_connects > 0:
+            self.fail_connects -= 1
+            raise ConnectionRefusedError("broker down")
+
+    def loop_start(self):
+        if self.on_connect:  # simulate a successful CONNACK
+            self.on_connect(self, None, {}, 0)
+
+    def loop_stop(self):
+        self.loop_stopped = True
+
+    def disconnect(self):
+        self.disconnected = True
+
+    def subscribe(self, topic, qos=0):
+        self.subscriptions.append((topic, qos))
+
+    def publish(self, topic, payload, qos=0):
+        self.publishes.append((topic, payload, qos))
+        if self.auto_reply is not None and self.on_message:
+            self.on_message(self, None, _Msg(json.dumps(self.auto_reply).encode()))
+        return _Info()
+
+    def emit(self, payload):  # test helper: deliver an event to a subscriber
+        self.on_message(self, None, _Msg(payload))
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    slept: list[float] = []
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(reliability.asyncio, "sleep", fake_sleep)
+    return slept
+
+
+def _form(href="mqtt://broker.local:1883/pump/cmd"):
+    action = SimpleNamespace(name="cmd")
+    form = SimpleNamespace(href=href, raw={})
+    return action, form
+
+
+def _enhanced_td():
+    return {
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "id": "urn:dev:x",
+        "title": "x",
+        "securityDefinitions": {"sc": {"scheme": "nosec"}},
+        "security": ["sc"],
+        "actions": {"cmd": {"forms": [{"href": "mqtt://broker/pump/cmd"}]}},
+    }
+
+
+async def test_v5_enhanced_auth_properties_reach_connect():
+    """End to end on the v5 path: EnhancedAuth material is built into CONNECT
+    properties (AuthenticationMethod/Data) and actually handed to the client's
+    connect() through the reliability connect path -- not merely constructed."""
+    captured: dict = {}
+
+    class _V5Fake(FakeClient):
+        def connect(self, host, port, **kwargs):
+            captured["properties"] = kwargs.get("properties")
+            super().connect(host, port)
+
+    thing = parse_thing(_enhanced_td())
+    ea = EnhancedAuth(method="K8S-SAT", data=b"sat-token")
+    inv = MqttInvoker(
+        credentials={"urn:dev:x": ea},
+        client_factory=lambda: _V5Fake(auto_reply={"ok": True}),
+    ).with_security(thing)
+    action = SimpleNamespace(name="cmd", thing_id="urn:dev:x")
+    form = SimpleNamespace(href="mqtt://broker/pump/cmd", raw={})
+
+    result = await inv.invoke(action, form, {})
+
+    assert result == {"ok": True}
+    props = captured["properties"]
+    assert props is not None  # the v5 properties really reached connect()
+    assert props.AuthenticationMethod == "K8S-SAT"
+    assert props.AuthenticationData == b"sat-token"
+
+
+async def test_invoke_round_trips_reply_at_qos1():
+    fake = FakeClient(auto_reply={"ok": True, "rpm": 900})
+    inv = MqttInvoker(client_factory=lambda: fake)
+    action, form = _form()
+
+    result = await inv.invoke(action, form, {"rpm": 900})
+
+    assert result == {"ok": True, "rpm": 900}
+    # Published to the command topic at QoS 1, subscribed to the reply topic.
+    assert fake.publishes == [("pump/cmd", json.dumps({"rpm": 900}), 1)]
+    assert ("pump/cmd/reply", 1) in fake.subscriptions
+
+
+async def test_connect_is_retried_with_backoff(no_sleep):
+    fake = FakeClient(fail_connects=2, auto_reply={"ok": True})
+    inv = MqttInvoker(client_factory=lambda: fake, connect_retries=3, backoff=0.1)
+    action, form = _form()
+
+    result = await inv.invoke(action, form, {})
+
+    assert result == {"ok": True}
+    assert fake.connect_calls == 3  # failed twice, succeeded on the third
+    # Exponential backoff between tries (base 0.1, 0.2) within the jitter band.
+    assert len(no_sleep) == 2
+    assert 0.1 <= no_sleep[0] <= 0.2
+    assert 0.2 <= no_sleep[1] <= 0.3
+    assert no_sleep[1] > no_sleep[0]
+
+
+async def test_connect_exhaustion_raises_transport_error(no_sleep):
+    fake = FakeClient(fail_connects=99)
+    inv = MqttInvoker(client_factory=lambda: fake, connect_retries=2, backoff=0)
+    action, form = _form()
+
+    with pytest.raises(TransportError) as ei:
+        await inv.invoke(action, form, {})
+
+    assert ei.value.method == "CONNECT"
+    assert ei.value.attempts == 3
+    assert isinstance(ei.value.__cause__, ConnectionRefusedError)
+    # A failed connect must not leak the client: it is torn down.
+    assert fake.loop_stopped and fake.disconnected
+
+
+async def test_connect_torn_down_and_retried_after_connack_timeout(no_sleep):
+    """A CONNACK that never arrives on the first attempt times out, tears the
+    connection fully down (loop_stop + disconnect), then a fresh attempt -- with
+    its own connect event -- succeeds."""
+
+    class SlowConnack:
+        def __init__(self):
+            self.loop_starts = self.stops = self.disconnects = 0
+            self.on_connect = self.on_message = None
+
+        def reconnect_delay_set(self, **kw):
+            pass
+
+        def connect(self, host, port):
+            pass
+
+        def loop_start(self):
+            self.loop_starts += 1
+            if self.loop_starts >= 2 and self.on_connect:  # CONNACK only on retry
+                self.on_connect(self, None, {}, 0)
+
+        def loop_stop(self):
+            self.stops += 1
+
+        def disconnect(self):
+            self.disconnects += 1
+
+        def subscribe(self, topic, qos=0):
+            pass
+
+        def publish(self, topic, payload, qos=0):
+            if self.on_message:
+                self.on_message(self, None, _Msg(json.dumps({"ok": True}).encode()))
+            return _Info()
+
+    fake = SlowConnack()
+    inv = MqttInvoker(
+        client_factory=lambda: fake, connect_retries=2, backoff=0, connect_timeout=0.05
+    )
+    action, form = _form()
+
+    result = await inv.invoke(action, form, {})
+
+    assert result == {"ok": True}
+    assert fake.loop_starts == 2  # first attempt timed out, retry succeeded
+    assert fake.stops >= 1 and fake.disconnects >= 1  # torn down between attempts
+
+
+async def test_reply_timeout_is_normalized():
+    fake = FakeClient(auto_reply=None)  # never replies
+    inv = MqttInvoker(client_factory=lambda: fake, timeout=0.05)
+    action, form = _form()
+
+    with pytest.raises(TransportError) as ei:
+        await inv.invoke(action, form, {})
+
+    assert ei.value.method == "PUBLISH"
+    assert "no reply" in ei.value.detail
+
+
+async def test_resubscribe_on_reconnect():
+    """paho does not resubscribe after a reconnect; the invoker's on_connect
+    must, so a second CONNACK re-establishes the subscription."""
+    fake = FakeClient(auto_reply={"ok": True})
+    inv = MqttInvoker(client_factory=lambda: fake)
+    action, form = _form()
+    await inv.invoke(action, form, {})
+
+    subs_after_first = [t for (t, _q) in fake.subscriptions]
+    assert "pump/cmd/reply" in subs_after_first
+
+    # Simulate a dropped connection re-establishing (paho fires on_connect again).
+    fake.on_connect(fake, None, {}, 0)
+    assert fake.subscriptions.count(("pump/cmd/reply", 1)) == 2
+
+
+async def test_invoke_shuts_down_client():
+    fake = FakeClient(auto_reply={"ok": True})
+    inv = MqttInvoker(client_factory=lambda: fake)
+    action, form = _form()
+
+    await inv.invoke(action, form, {})
+
+    assert fake.loop_stopped and fake.disconnected
+
+
+async def test_subscribe_streams_and_decodes():
+    fake = FakeClient()
+    inv = MqttInvoker(client_factory=lambda: fake, qos=1)
+    _action, form = _form("mqtt://broker.local/pump/events")
+
+    stream = await inv.subscribe("pump.overheat", form)
+    assert ("pump/events", 1) in fake.subscriptions  # subscribed at QoS 1
+
+    fake.emit(json.dumps({"temp": 98}).encode())
+    fake.emit(b"not-json")
+
+    first = await stream.__anext__()
+    second = await stream.__anext__()
+    assert first == {"temp": 98}
+    assert second == "not-json"  # non-JSON falls back to text
+
+    await stream.aclose()
+    assert fake.loop_stopped and fake.disconnected

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,0 +1,313 @@
+"""HttpInvoker reliability + chaos.
+
+Two layers of testing here:
+
+* deterministic logic tests (retry control flow, error normalization, pooling);
+* chaos tests that inject randomized and timing-sensitive faults (random
+  failure depth, backoff/Retry-After timing, every httpx timeout type, and
+  concurrent load on the shared client).
+
+Retries are gated to idempotent methods by default, so a POST is never silently
+re-sent; that boundary is tested explicitly.
+"""
+
+from __future__ import annotations
+
+import random
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+import thingctx.reliability as reliability
+from thingctx import HttpInvoker, TransportError
+from thingctx.reliability import RetryPolicy, send_with_retry
+
+
+def _af(method="GET", href="https://api.local/do"):
+    action = SimpleNamespace(thing_id=None, idempotent=method.upper() in ("GET", "HEAD"))
+    form = SimpleNamespace(href=href, raw={"htv:methodName": method})
+    return action, form
+
+
+@pytest.fixture
+def routed(monkeypatch):
+    """Drive every AsyncClient through a handler the test controls, and count
+    requests and how many underlying clients get built (to prove pooling)."""
+    state = {"responses": [], "calls": 0, "clients": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        state["calls"] += 1
+        nxt = state["responses"].pop(0)
+        return nxt(request) if callable(nxt) else nxt
+
+    real = httpx.AsyncClient
+
+    def fake(*args, **kwargs):
+        state["clients"] += 1
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", fake)
+    return state
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Replace the backoff sleep with a recorder, so timing is asserted without
+    real delays."""
+    slept: list[float] = []
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(reliability.asyncio, "sleep", fake_sleep)
+    return slept
+
+
+# --- deterministic logic ---------------------------------------------------
+
+
+async def test_retries_then_succeeds(routed):
+    routed["responses"] = [
+        httpx.Response(503),
+        httpx.Response(503),
+        httpx.Response(200, json={"ok": True}),
+    ]
+    inv = HttpInvoker(backoff=0)
+    action, form = _af("PUT")
+
+    result = await inv.invoke(action, form, {})
+
+    assert result == {"ok": True}
+    assert routed["calls"] == 3
+    await inv.aclose()
+
+
+async def test_transient_failures_exhaust_to_transport_error(routed):
+    routed["responses"] = [httpx.Response(503)] * 3
+    inv = HttpInvoker(backoff=0)
+    action, form = _af("PUT")
+
+    with pytest.raises(TransportError) as ei:
+        await inv.invoke(action, form, {})
+
+    assert ei.value.status == 503
+    assert ei.value.attempts == 3
+    assert ei.value.as_dict()["ok"] is False
+    await inv.aclose()
+
+
+async def test_non_retryable_4xx_raises_immediately(routed):
+    routed["responses"] = [httpx.Response(404, text="nope")]
+    inv = HttpInvoker(backoff=0)
+    action, form = _af("GET")
+
+    with pytest.raises(TransportError) as ei:
+        await inv.invoke(action, form, {})
+
+    assert ei.value.status == 404
+    assert ei.value.attempts == 1
+    assert routed["calls"] == 1
+    await inv.aclose()
+
+
+async def test_connection_error_is_retried_then_normalized(routed):
+    def boom(_request):
+        raise httpx.ConnectError("refused")
+
+    routed["responses"] = [boom, boom, boom]
+    inv = HttpInvoker(backoff=0)
+    action, form = _af("GET")
+
+    with pytest.raises(TransportError) as ei:
+        await inv.invoke(action, form, {})
+
+    assert ei.value.status is None
+    assert isinstance(ei.value.__cause__, httpx.ConnectError)
+    assert routed["calls"] == 3
+    await inv.aclose()
+
+
+async def test_client_is_pooled_across_calls(routed):
+    routed["responses"] = [httpx.Response(200, json={"n": 1}), httpx.Response(200, json={"n": 2})]
+    inv = HttpInvoker(backoff=0)
+    action, form = _af("GET")
+
+    await inv.invoke(action, form, {})
+    await inv.invoke(action, form, {})
+
+    assert routed["clients"] == 1
+    await inv.aclose()
+
+
+async def test_context_manager_closes(routed):
+    routed["responses"] = [httpx.Response(200, json={"ok": True})]
+    async with HttpInvoker(backoff=0) as inv:
+        action, form = _af("GET")
+        await inv.invoke(action, form, {})
+        client = inv._client
+        assert client is not None
+    assert client.is_closed
+
+
+# --- idempotency guard -----------------------------------------------------
+
+
+async def test_post_is_not_retried_by_default(routed):
+    routed["responses"] = [httpx.Response(503), httpx.Response(200, json={"ok": True})]
+    inv = HttpInvoker(backoff=0)
+    action, form = _af("POST")
+
+    with pytest.raises(TransportError) as ei:
+        await inv.invoke(action, form, {})
+
+    assert ei.value.attempts == 1  # the write was sent once, not retried
+    assert routed["calls"] == 1
+    await inv.aclose()
+
+
+async def test_post_retried_when_opted_in(routed):
+    routed["responses"] = [
+        httpx.Response(503),
+        httpx.Response(503),
+        httpx.Response(200, json={"ok": True}),
+    ]
+    inv = HttpInvoker(backoff=0, retry_non_idempotent=True)
+    action, form = _af("POST")
+
+    result = await inv.invoke(action, form, {})
+
+    assert result == {"ok": True}
+    assert routed["calls"] == 3
+    await inv.aclose()
+
+
+# --- chaos: randomized fault depth -----------------------------------------
+
+
+async def test_randomized_fault_depth(routed, no_sleep):
+    """For a random number of leading failures, an idempotent call succeeds iff
+    the failure count fits the retry budget, with exactly failures+1 attempts."""
+    rng = random.Random(20260619)
+    retries = 3
+    for _ in range(120):
+        fails = rng.randint(0, retries + 1)
+        ok = httpx.Response(200, json={"ok": True})
+        routed["responses"] = [httpx.Response(503) for _ in range(fails)] + [ok]
+        routed["calls"] = 0
+        inv = HttpInvoker(backoff=0, retries=retries)
+        action, form = _af("GET")
+        if fails <= retries:
+            assert await inv.invoke(action, form, {}) == {"ok": True}
+            assert routed["calls"] == fails + 1
+        else:
+            with pytest.raises(TransportError):
+                await inv.invoke(action, form, {})
+            assert routed["calls"] == retries + 1
+        await inv.aclose()
+
+
+# --- chaos: backoff + Retry-After timing -----------------------------------
+
+
+def test_backoff_schedule_is_exponential_and_capped():
+    p = RetryPolicy(retries=5, backoff=0.1, jitter=0.0, max_backoff=1.0)
+    assert p.delay(0) == pytest.approx(0.1)
+    assert p.delay(1) == pytest.approx(0.2)
+    assert p.delay(2) == pytest.approx(0.4)
+    assert p.delay(10) == pytest.approx(1.0)  # capped at max_backoff
+
+
+def test_jitter_stays_in_bounds():
+    p = RetryPolicy(backoff=0.1, jitter=0.5)
+    for _ in range(200):
+        d = p.delay(0)
+        assert 0.1 <= d <= 0.6
+
+
+class _FakeClient:
+    """A minimal stand-in whose .request replays a scripted sequence (responses
+    or exceptions). Enough for send_with_retry, which only reads status/headers."""
+
+    def __init__(self, sequence):
+        self._seq = list(sequence)
+        self.calls = 0
+
+    async def request(self, method, url, **kwargs):
+        self.calls += 1
+        nxt = self._seq.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+
+async def test_sleeps_follow_exponential_backoff(no_sleep):
+    client = _FakeClient([httpx.Response(503)] * 3 + [httpx.Response(200)])
+    policy = RetryPolicy(retries=3, backoff=0.1, jitter=0.0)
+
+    resp, attempts = await send_with_retry(client, "GET", "https://x/", policy=policy)
+
+    assert resp.status_code == 200
+    assert attempts == 4
+    assert no_sleep == pytest.approx([0.1, 0.2, 0.4])
+
+
+async def test_retry_after_header_is_honored(no_sleep):
+    client = _FakeClient([httpx.Response(503, headers={"Retry-After": "2"}), httpx.Response(200)])
+    policy = RetryPolicy(retries=3, backoff=0.1, jitter=0.0, max_backoff=5.0)
+
+    await send_with_retry(client, "GET", "https://x/", policy=policy)
+
+    assert no_sleep[0] == 2.0  # waited the server's Retry-After, not the backoff
+
+
+# --- chaos: every timeout type ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError("c"),
+        httpx.ConnectTimeout("ct"),
+        httpx.ReadTimeout("rt"),
+        httpx.PoolTimeout("pt"),
+        httpx.WriteError("we"),
+    ],
+)
+async def test_all_transport_errors_are_retried_and_normalized(routed, no_sleep, exc):
+    def boom(_request):
+        raise exc
+
+    routed["responses"] = [boom, boom, boom]
+    inv = HttpInvoker(backoff=0, retries=2)
+    action, form = _af("GET")
+
+    with pytest.raises(TransportError) as ei:
+        await inv.invoke(action, form, {})
+
+    assert type(ei.value.__cause__) is type(exc)
+    assert routed["calls"] == 3
+    await inv.aclose()
+
+
+# --- chaos: concurrent load on the pooled client ---------------------------
+
+
+async def test_concurrent_calls_share_one_pooled_client(routed):
+    import asyncio
+
+    n = 40
+    routed["responses"] = [httpx.Response(200, json={"ok": True}) for _ in range(n)]
+    inv = HttpInvoker(backoff=0)
+
+    async def call():
+        action, form = _af("GET")
+        return await inv.invoke(action, form, {})
+
+    results = await asyncio.gather(*(call() for _ in range(n)))
+
+    assert all(r == {"ok": True} for r in results)
+    assert routed["calls"] == n
+    assert routed["clients"] == 1  # one client served all concurrent calls
+    await inv.aclose()


### PR DESCRIPTION
Bounded retries with backoff+jitter and one normalized `TransportError`; applied to HTTP and MQTT (reconnect, QoS 1, resubscribe).