### PR TITLE
docs: interop demos (node-wot, Eclipse Ditto)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,6 +13,9 @@ description = "Non-secret fixtures and public test vectors"
 regexes = [
   '''AKIDEXAMPLE''',
   '''wJalrXUtnFEMI/K7MDENG\+bPxRfiCYEXAMPLEKEY''',
+  # Documented public default dev credential for the Eclipse Ditto sandbox,
+  # used verbatim in the interop demo (not a real secret).
+  '''ditto:ditto''',
 ]
 # Obvious placeholder tokens used in tests and examples.
 stopwords = [

--- a/README.md
+++ b/README.md
@@ -188,6 +188,23 @@ three; the difference is the server you build and run to get there. The Thing
 Description is data, about 145 lines of JSON, written once and read by every
 consumer. Reproduce with `python examples/_measure.py`.
 
+## Interoperability
+
+thingctx consumes a Thing Description whoever wrote it — including TDs emitted
+by standards-compliant producers, not just hand-written ones. Two demos under
+[`examples/interop/`](examples/interop/) prove it end to end:
+
+- [**node-wot**](examples/interop/nodewot/) — the
+  [W3C WoT reference implementation](https://github.com/eclipse-thingweb/node-wot)
+  exposes a `counter` Thing; thingctx fetches its served TD and drives it
+  (read, increment, read) with no node-wot client in the loop.
+- [**Eclipse Ditto**](examples/interop/ditto/) — Ditto generates a TD for a
+  digital twin; thingctx consumes it and round-trips twin state straight
+  through Ditto's API.
+
+Same consumer, different producers, zero glue: any conformant TD producer →
+thingctx.
+
 ## Reference
 
 ### ThingClient: the core

--- a/examples/interop/README.md
+++ b/examples/interop/README.md
@@ -1,0 +1,14 @@
+# Interoperability demos
+
+thingctx is a *consumer*: point it at any conformant Thing Description and it
+drives the Thing, whoever produced the TD. These demos prove that against real,
+machine-generating producers — not hand-written fixtures.
+
+- [`nodewot/`](nodewot/) — the **W3C WoT reference implementation** (node-wot)
+  exposes a Thing; thingctx consumes its served TD and drives it.
+- [`ditto/`](ditto/) — **Eclipse Ditto** generates a TD for a digital twin;
+  thingctx consumes it and round-trips twin state.
+
+Each demo stands alone: a producer (or a captured TD), a `drive_*.py` consumer,
+and a README with reproduction steps and a verified run. The TD is the only
+contract between producer and consumer.

--- a/examples/interop/ditto/README.md
+++ b/examples/interop/ditto/README.md
@@ -77,5 +77,5 @@ Credentials default to Ditto's compose defaults (`ditto:ditto`); override with
 Ditto (and Bosch IoT Things behind it) is a credible, standards-compliant TD
 producer for industrial digital twins. That a twin it generated drops straight
 into thingctx with zero glue is the point: **any conformant TD producer →
-thingctx**. thingctx is a consumer, complementary to Ditto, td-registry, and
-thingdir — not a competitor to any of them.
+thingctx**. thingctx is a consumer, complementary to TD producers and
+directories — not a competitor to any of them.

--- a/examples/interop/ditto/README.md
+++ b/examples/interop/ditto/README.md
@@ -1,0 +1,81 @@
+# Ditto-generated TD → thingctx
+
+A small interop demo: **Eclipse Ditto produces a W3C Thing Description, and
+thingctx consumes it** — turning a real digital twin into callable
+properties/actions and LLM tool specs, with no Ditto-specific code, no SDK, and
+no MCP server. Just the description.
+
+A conformance check: it proves thingctx consumes a real, machine-generated TD
+from a standards-compliant producer, not only hand-written ones.
+
+## What it shows
+
+```
+Thing Model (WoT)  ──put──►  Eclipse Ditto  ──Accept: application/td+json──►  TD
+                                                                              │
+                                                              thingctx.ThingClient(tds=[td])
+                                                                              │
+                                       read/write twin state · LLM tool specs ▼
+```
+
+Ditto is the **producer**: hand it a Thing Model URL, it stores a twin and, on
+request, emits a conformant TD whose `forms` describe how to reach that twin
+over its HTTP API (hrefs, methods, `basic` security). thingctx is the
+**consumer**: it reads that TD and exposes the twin. They never knew about each
+other — the TD is the only contract.
+
+## Files
+
+- `ditto-generated-td.json` — the TD **Ditto generated** (the fixture). Note
+  `base`, the `basic_sc` security scheme, the `attributes/*` property forms with
+  `htv:methodName`, and the `inbox/messages/*` action forms.
+- `drive_ditto_td.py` — consumes that TD with thingctx and drives the live twin.
+- `capture_td.sh` — reproduces the fixture from scratch (Docker → Ditto → TD).
+
+## Result (live run)
+
+thingctx, given only the generated TD, projected the twin to tools and
+round-tripped a property straight through to Ditto:
+
+```
+actions exposed as tools: ['lamp-1.toggle', 'lamp-1.switch-on-for-duration']
+properties: ['lamp-1.on', 'lamp-1.color', 'lamp-1.dimmer-level']
+
+read  dimmer-level -> 0.0
+write dimmer-level <- 0.42
+read  dimmer-level -> 0.42
+
+OK: thingctx drove a Ditto twin using only the generated TD.
+```
+
+Confirmed independently against Ditto's API — the twin's
+`attributes.dimmer-level` became `0.42`. The property read/write path is fully
+server-side (twin state), so it works without a physical device attached. The
+`toggle`/`switch-on-for-duration` actions map to Ditto *messages*
+(`inbox/messages/*`) and would need a device consuming them to complete.
+
+## Reproduce
+
+```bash
+# 1. Bring up Ditto and capture the TD (needs Docker)
+./capture_td.sh
+
+# 2. Drive the twin with thingctx
+python3 -m venv .venv && . .venv/bin/activate
+pip install "thingctx[http]==0.1.3"
+python drive_ditto_td.py
+
+# 3. Tear down
+( cd .ditto-src/deployment/docker && docker compose down -v )
+```
+
+Credentials default to Ditto's compose defaults (`ditto:ditto`); override with
+`DITTO_CREDS=user:pass`.
+
+## Takeaway
+
+Ditto (and Bosch IoT Things behind it) is a credible, standards-compliant TD
+producer for industrial digital twins. That a twin it generated drops straight
+into thingctx with zero glue is the point: **any conformant TD producer →
+thingctx**. thingctx is a consumer, complementary to Ditto, td-registry, and
+thingdir — not a competitor to any of them.

--- a/examples/interop/ditto/capture_td.sh
+++ b/examples/interop/ditto/capture_td.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Reproduce the Ditto-generated TD fixture from scratch.
+#
+# Prereqs: Docker running. Brings up the Eclipse Ditto docker-compose stack,
+# creates a twin from a public WoT Thing Model, and captures the TD that Ditto
+# generates. Ditto is the TD *producer*; drive_ditto_td.py is the consumer.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DITTO_SRC="$HERE/.ditto-src"
+THING_ID="org.thingctx:lamp-1"
+TM="https://eclipse.dev/ditto/wot/example-models/dimmable-colored-lamp-1.0.0.tm.jsonld"
+BASE="http://localhost:8080/api/2"
+
+# 1. Get Ditto's official compose stack (shallow) and start it.
+[ -d "$DITTO_SRC" ] || git clone --depth 1 https://github.com/eclipse-ditto/ditto.git "$DITTO_SRC"
+( cd "$DITTO_SRC/deployment/docker" && docker compose up -d )
+
+# 2. Wait for the gateway (behind nginx, basic auth ditto:ditto) to be ready.
+echo "waiting for Ditto..."
+until [ "$(curl -s -o /dev/null -w '%{http_code}' -u ditto:ditto "$BASE/things")" = "200" ]; do
+  sleep 3
+done
+
+# 3. Create a twin whose definition points at the WoT Thing Model. Ditto
+#    generates the thing skeleton (attributes) from the model.
+curl -s -u ditto:ditto -X PUT "$BASE/things/$THING_ID" \
+  -H 'Content-Type: application/json' \
+  -d "{\"definition\":\"$TM\"}" >/dev/null
+
+# 4. Ask Ditto for the TD describing that twin (content negotiation).
+curl -s -u ditto:ditto -H 'Accept: application/td+json' \
+  "$BASE/things/$THING_ID" | python3 -m json.tool > "$HERE/ditto-generated-td.json"
+
+echo "captured -> ditto-generated-td.json"

--- a/examples/interop/ditto/capture_td.sh
+++ b/examples/interop/ditto/capture_td.sh
@@ -16,20 +16,27 @@ BASE="http://localhost:8080/api/2"
 [ -d "$DITTO_SRC" ] || git clone --depth 1 https://github.com/eclipse-ditto/ditto.git "$DITTO_SRC"
 ( cd "$DITTO_SRC/deployment/docker" && docker compose up -d )
 
-# 2. Wait for the gateway (behind nginx, basic auth ditto:ditto) to be ready.
+# 2. Wait for the gateway (behind nginx, basic auth ditto:ditto) to be ready,
+#    giving up after a bounded number of attempts so a stuck stack fails loudly.
 echo "waiting for Ditto..."
-until [ "$(curl -s -o /dev/null -w '%{http_code}' -u ditto:ditto "$BASE/things")" = "200" ]; do
+for _ in $(seq 1 60); do
+  [ "$(curl -s -o /dev/null -w '%{http_code}' -u ditto:ditto "$BASE/things")" = "200" ] && break
   sleep 3
 done
+if [ "$(curl -s -o /dev/null -w '%{http_code}' -u ditto:ditto "$BASE/things")" != "200" ]; then
+  echo "Ditto did not become ready in time" >&2
+  exit 1
+fi
 
 # 3. Create a twin whose definition points at the WoT Thing Model. Ditto
-#    generates the thing skeleton (attributes) from the model.
-curl -s -u ditto:ditto -X PUT "$BASE/things/$THING_ID" \
+#    generates the thing skeleton (attributes) from the model. -f makes curl
+#    fail on an HTTP error response instead of exiting 0 with an error body.
+curl -fsS -u ditto:ditto -X PUT "$BASE/things/$THING_ID" \
   -H 'Content-Type: application/json' \
   -d "{\"definition\":\"$TM\"}" >/dev/null
 
 # 4. Ask Ditto for the TD describing that twin (content negotiation).
-curl -s -u ditto:ditto -H 'Accept: application/td+json' \
+curl -fsS -u ditto:ditto -H 'Accept: application/td+json' \
   "$BASE/things/$THING_ID" | python3 -m json.tool > "$HERE/ditto-generated-td.json"
 
 echo "captured -> ditto-generated-td.json"

--- a/examples/interop/ditto/ditto-generated-td.json
+++ b/examples/interop/ditto/ditto-generated-td.json
@@ -1,0 +1,423 @@
+{
+    "@context": [
+        "https://www.w3.org/2022/wot/td/v1.1",
+        {
+            "om2": "http://www.ontology-of-units-of-measure.org/resource/om-2/"
+        }
+    ],
+    "title": "Dimmable Colored Lamp",
+    "@type": "Thing",
+    "id": "urn:org.thingctx:lamp-1",
+    "base": "http://localhost:8080/api/2/things/org.thingctx:lamp-1/",
+    "version": {
+        "model": "1.0.0",
+        "instance": "1.0.0"
+    },
+    "links": [
+        {
+            "rel": "type",
+            "href": "https://eclipse.dev/ditto/wot/example-models/dimmable-colored-lamp-1.0.0.tm.jsonld",
+            "type": "application/tm+json"
+        }
+    ],
+    "security": "basic_sc",
+    "securityDefinitions": {
+        "basic_sc": {
+            "in": "header",
+            "scheme": "basic"
+        }
+    },
+    "support": "https://www.eclipse.dev/ditto/",
+    "created": "2026-06-18T02:05:31.521229997Z",
+    "forms": [
+        {
+            "op": "readallproperties",
+            "href": "attributes",
+            "htv:methodName": "GET",
+            "contentType": "application/json",
+            "additionalResponses": [
+                {
+                    "success": false,
+                    "schema": "dittoError"
+                }
+            ]
+        },
+        {
+            "op": "readmultipleproperties",
+            "href": "attributes",
+            "htv:methodName": "GET",
+            "contentType": "application/json",
+            "additionalResponses": [
+                {
+                    "success": false,
+                    "schema": "dittoError"
+                }
+            ]
+        },
+        {
+            "op": "writeallproperties",
+            "href": "attributes",
+            "htv:methodName": "PUT",
+            "contentType": "application/json",
+            "additionalResponses": [
+                {
+                    "success": false,
+                    "schema": "dittoError"
+                }
+            ]
+        },
+        {
+            "op": "writemultipleproperties",
+            "href": "attributes",
+            "htv:methodName": "PATCH",
+            "contentType": "application/merge-patch+json",
+            "additionalResponses": [
+                {
+                    "success": false,
+                    "schema": "dittoError"
+                }
+            ]
+        },
+        {
+            "op": [
+                "observeallproperties",
+                "unobserveallproperties"
+            ],
+            "href": "attributes",
+            "htv:methodName": "GET",
+            "subprotocol": "sse",
+            "contentType": "text/event-stream",
+            "additionalResponses": [
+                {
+                    "success": false,
+                    "schema": "dittoError"
+                }
+            ]
+        },
+        {
+            "op": [
+                "subscribeallevents",
+                "unsubscribeallevents"
+            ],
+            "href": "outbox/messages",
+            "htv:methodName": "GET",
+            "subprotocol": "sse",
+            "contentType": "text/event-stream",
+            "additionalResponses": [
+                {
+                    "success": false,
+                    "schema": "dittoError"
+                }
+            ]
+        }
+    ],
+    "properties": {
+        "on": {
+            "title": "On",
+            "description": "Whether the switch is on or off.",
+            "type": "boolean",
+            "observable": true,
+            "forms": [
+                {
+                    "op": "readproperty",
+                    "href": "attributes/on",
+                    "htv:methodName": "GET",
+                    "contentType": "application/json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                },
+                {
+                    "op": "writeproperty",
+                    "href": "attributes/on",
+                    "htv:methodName": "PUT",
+                    "contentType": "application/json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                },
+                {
+                    "op": "writeproperty",
+                    "href": "attributes/on",
+                    "htv:methodName": "PATCH",
+                    "contentType": "application/merge-patch+json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                },
+                {
+                    "op": [
+                        "observeproperty",
+                        "unobserveproperty"
+                    ],
+                    "href": "attributes/on",
+                    "htv:methodName": "GET",
+                    "subprotocol": "sse",
+                    "contentType": "text/event-stream",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                }
+            ]
+        },
+        "color": {
+            "title": "Color",
+            "description": "The current color.",
+            "type": "object",
+            "properties": {
+                "r": {
+                    "title": "Red",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255
+                },
+                "g": {
+                    "title": "Green",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255
+                },
+                "b": {
+                    "title": "Blue",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255
+                },
+                "w": {
+                    "title": "White",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255
+                }
+            },
+            "required": [
+                "r",
+                "g",
+                "b"
+            ],
+            "observable": true,
+            "forms": [
+                {
+                    "op": "readproperty",
+                    "href": "attributes/color",
+                    "htv:methodName": "GET",
+                    "contentType": "application/json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                },
+                {
+                    "op": "writeproperty",
+                    "href": "attributes/color",
+                    "htv:methodName": "PUT",
+                    "contentType": "application/json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                },
+                {
+                    "op": "writeproperty",
+                    "href": "attributes/color",
+                    "htv:methodName": "PATCH",
+                    "contentType": "application/merge-patch+json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                },
+                {
+                    "op": [
+                        "observeproperty",
+                        "unobserveproperty"
+                    ],
+                    "href": "attributes/color",
+                    "htv:methodName": "GET",
+                    "subprotocol": "sse",
+                    "contentType": "text/event-stream",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                }
+            ]
+        },
+        "dimmer-level": {
+            "@type": "om2:Percentage",
+            "title": "Dimmer level",
+            "type": "number",
+            "unit": "om2:percent",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "multipleOf": 0.001,
+            "observable": true,
+            "forms": [
+                {
+                    "op": "readproperty",
+                    "href": "attributes/dimmer-level",
+                    "htv:methodName": "GET",
+                    "contentType": "application/json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                },
+                {
+                    "op": "writeproperty",
+                    "href": "attributes/dimmer-level",
+                    "htv:methodName": "PUT",
+                    "contentType": "application/json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                },
+                {
+                    "op": "writeproperty",
+                    "href": "attributes/dimmer-level",
+                    "htv:methodName": "PATCH",
+                    "contentType": "application/merge-patch+json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                },
+                {
+                    "op": [
+                        "observeproperty",
+                        "unobserveproperty"
+                    ],
+                    "href": "attributes/dimmer-level",
+                    "htv:methodName": "GET",
+                    "subprotocol": "sse",
+                    "contentType": "text/event-stream",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "actions": {
+        "toggle": {
+            "title": "Toggle",
+            "description": "Toggles/inverts the current 'on' state.",
+            "output": {
+                "title": "New 'on' state",
+                "type": "boolean"
+            },
+            "synchronous": true,
+            "forms": [
+                {
+                    "op": "invokeaction",
+                    "href": "inbox/messages/toggle",
+                    "htv:methodName": "POST",
+                    "contentType": "application/json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                }
+            ]
+        },
+        "switch-on-for-duration": {
+            "title": "Switch on for duration",
+            "description": "Switches the switchable on for a given duration, then switches back to the previous state.",
+            "input": {
+                "@type": "time:Duration",
+                "title": "Duration in seconds",
+                "type": "integer",
+                "unit": "time:seconds"
+            },
+            "synchronous": true,
+            "forms": [
+                {
+                    "op": "invokeaction",
+                    "href": "inbox/messages/switch-on-for-duration",
+                    "htv:methodName": "POST",
+                    "contentType": "application/json",
+                    "additionalResponses": [
+                        {
+                            "success": false,
+                            "schema": "dittoError"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "schemaDefinitions": {
+        "dittoError": {
+            "type": "object",
+            "title": "Ditto error.",
+            "description": "Provides additional information about an occurred error and how to resolve it.",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "title": "Error description.",
+                    "description": "Contains further information about the error e.g. a hint what caused the problem and how to solve it."
+                },
+                "status": {
+                    "type": "integer",
+                    "title": "Status code.",
+                    "description": "The status code of the error with HTTP status code semantics (e.g.: 4xx for user errors, 5xx for server errors).",
+                    "minimum": 400,
+                    "maximum": 599
+                },
+                "href": {
+                    "type": "string",
+                    "title": "Error link.",
+                    "description": "A link to further information about the error and how to fix it.",
+                    "format": "uri"
+                },
+                "message": {
+                    "type": "string",
+                    "title": "Error message.",
+                    "description": "The human readable message that explains what went wrong during the execution of a command/message."
+                },
+                "error": {
+                    "type": "string",
+                    "title": "Error code identifier.",
+                    "description": "The error code or identifier that uniquely identifies the error."
+                }
+            },
+            "required": [
+                "status",
+                "error",
+                "message"
+            ]
+        }
+    }
+}

--- a/examples/interop/ditto/drive_ditto_td.py
+++ b/examples/interop/ditto/drive_ditto_td.py
@@ -1,0 +1,59 @@
+"""Drive an Eclipse Ditto digital twin with thingctx, using only the TD that
+Ditto generated from a W3C WoT Thing Model.
+
+Ditto is the *producer*: you hand it a Thing Model URL, it stores a twin and,
+on request, emits a conformant W3C TD describing how to talk to that twin over
+its HTTP API (forms, methods, security). thingctx is the *consumer*: it reads
+that TD and turns it into callable properties/actions + LLM tool specs. No
+glue code, no Ditto-specific SDK, no MCP server -- just the description.
+
+Run (with Ditto up on :8080 and the TD captured to ditto-generated-td.json):
+
+    python drive_ditto_td.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import pathlib
+
+from thingctx.invokers import HttpInvoker
+from thingctx.runtime import ThingClient
+
+TD_PATH = pathlib.Path(__file__).with_name("ditto-generated-td.json")
+# Ditto's default docker-compose stack: nginx basic auth, user:pass = ditto:ditto.
+CREDS = os.environ.get("DITTO_CREDS", "ditto:ditto")
+
+
+async def main() -> None:
+    td = json.loads(TD_PATH.read_text())
+    print(f"Ditto-generated TD: id={td['id']}  base={td['base']}")
+    print(f"  security={td['security']}  scheme={td['securityDefinitions']}")
+
+    # The TD names the security scheme ("basic_sc"); we supply the secret.
+    http = HttpInvoker(credentials={"basic_sc": CREDS})
+    client = ThingClient(tds=[td], invokers=[http])
+
+    # 1. The Ditto TD -> LLM tool specs, for free.
+    print("\nactions exposed as tools:", [t["function"]["name"] for t in client.list_actions()])
+    print("properties:", client.list_properties())
+
+    # 2. Read -> write -> read a property, straight through to the live twin.
+    before = await client.read_property("lamp-1.dimmer-level")
+    print(f"\nread  dimmer-level -> {before}")
+
+    new_value = 0.42
+    await client.write_property("lamp-1.dimmer-level", new_value)
+    print(f"write dimmer-level <- {new_value}")
+
+    after = await client.read_property("lamp-1.dimmer-level")
+    print(f"read  dimmer-level -> {after}")
+
+    assert after == new_value, f"expected {new_value}, got {after}"
+    print("\nOK: thingctx drove a Ditto twin using only the generated TD.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/interop/nodewot/README.md
+++ b/examples/interop/nodewot/README.md
@@ -1,0 +1,60 @@
+# node-wot-produced TD → thingctx
+
+node-wot (the W3C WoT reference implementation) produces a Thing Description;
+thingctx consumes it and drives the Thing using only that TD — no node-wot
+client, SDK, or MCP server.
+
+A conformance check (same shape as [`../ditto`](../ditto)): thingctx consumes
+the reference implementation's own TD, with no node-wot client in the loop.
+
+## What it shows
+
+```
+node-wot Servient ──exposes──► http://localhost:8080/counter (its TD)
+                                           │
+                            thingctx.from_url(...) / ThingClient(tds=[td])
+                                           │
+                    read count · invokeAction increment · read count ▼
+```
+
+node-wot is the producer (a Servient exposing a `counter` Thing and its TD at
+`/counter`); thingctx is the consumer (fetches the TD, turns its
+properties/actions into callable methods and LLM tool specs). The TD is the only
+contract.
+
+## Files
+
+- `producer.js` — minimal node-wot Servient exposing the `counter` Thing.
+- `drive_nodewot_td.py` — consumes the served TD with thingctx and drives it.
+
+## Reproduce
+
+```bash
+# 1. Start the node-wot producer (needs Node 18+)
+npm init -y && npm install @node-wot/core @node-wot/binding-http
+node producer.js          # serves http://localhost:8080/counter
+
+# 2. In another shell, drive it with thingctx
+python3 -m venv .venv && . .venv/bin/activate
+pip install "thingctx[http]"
+python drive_nodewot_td.py
+```
+
+## Result (verified live)
+
+```
+counter TD: id=urn:dev:counter  title=counter
+actions exposed as tools: ['counter.increment', 'counter.decrement', 'counter.reset']
+properties: ['counter.count']
+
+read  count -> 0
+invoke increment
+read  count -> 1
+```
+
+## Note: Thing id and slug
+
+node-wot defaults a Thing's `id` to a random `urn:uuid:...`, and thingctx derives
+the address prefix (slug) from that id. Either set a stable `id` in the producer
+(this demo uses `urn:dev:counter`) or derive the prefix at runtime (the driver
+does `client.list_properties()[0].split(".")[0]`), which works for any producer.

--- a/examples/interop/nodewot/drive_nodewot_td.py
+++ b/examples/interop/nodewot/drive_nodewot_td.py
@@ -1,0 +1,54 @@
+"""Drive a node-wot Thing with thingctx, using only the TD that node-wot (the
+W3C WoT reference implementation) serves.
+
+node-wot is the producer (see producer.js); thingctx is the consumer: it fetches
+the served TD and turns it into callable properties/actions + LLM tool specs. No
+node-wot client, no SDK, no MCP server.
+
+Run (with producer.js running on :8080):
+
+    python drive_nodewot_td.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import httpx
+
+from thingctx.invokers import HttpInvoker
+from thingctx.runtime import ThingClient
+
+TD_URL = os.environ.get("NODEWOT_TD_URL", "http://localhost:8080/counter")
+
+
+async def main() -> None:
+    async with httpx.AsyncClient() as http:
+        td = (await http.get(TD_URL)).json()
+    print(f"counter TD: id={td.get('id')}  title={td.get('title')}")
+
+    client = ThingClient(tds=[td], invokers=[HttpInvoker()])
+    print("actions exposed as tools:", [t["function"]["name"] for t in client.list_actions()])
+    print("properties:", client.list_properties())
+
+    # Address by the Thing's slug, which thingctx derives from the TD id.
+    # node-wot defaults to a random urn:uuid id, so derive it rather than
+    # hard-coding -- the demo then works for any producer.
+    slug = client.list_properties()[0].split(".", 1)[0]
+
+    before = await client.read_property(f"{slug}.count")
+    print(f"\nread  count -> {before}")
+
+    await client.invoke(f"{slug}.increment", {})
+    print("invoke increment")
+
+    after = await client.read_property(f"{slug}.count")
+    print(f"read  count -> {after}")
+
+    assert after == before + 1, f"expected {before + 1}, got {after}"
+    print("\nOK: thingctx drove a node-wot Thing using only its served TD.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/interop/nodewot/package.json
+++ b/examples/interop/nodewot/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nodewot-interop",
+  "version": "1.0.0",
+  "description": "An interop demo: **node-wot (the W3C WoT reference implementation) produces a Thing Description, and thingctx consumes it** — driving a live Thing with no node-wot client, no SDK, no MCP server. Just the description.",
+  "main": "producer.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@node-wot/binding-http": "^0.9.2",
+    "@node-wot/core": "^0.9.2"
+  }
+}

--- a/examples/interop/nodewot/producer.js
+++ b/examples/interop/nodewot/producer.js
@@ -1,0 +1,38 @@
+// Minimal node-wot producer: exposes a `counter` Thing and serves its TD at
+// http://localhost:8080/counter. The W3C reference implementation generates the
+// Thing Description; thingctx consumes it (see drive_nodewot_td.py).
+//
+//   npm install @node-wot/core @node-wot/binding-http
+//   node producer.js
+
+const { Servient } = require("@node-wot/core");
+const { HttpServer } = require("@node-wot/binding-http");
+
+const servient = new Servient();
+servient.addServer(new HttpServer({ port: 8080 }));
+
+servient.start().then(async (WoT) => {
+  let count = 0;
+
+  const thing = await WoT.produce({
+    id: "urn:dev:counter",
+    title: "counter",
+    description: "A simple counter Thing.",
+    properties: {
+      count: { type: "integer", readOnly: true, observable: true },
+    },
+    actions: {
+      increment: { description: "Add one to the count." },
+      decrement: { description: "Subtract one from the count." },
+      reset: { description: "Reset the count to zero." },
+    },
+  });
+
+  thing.setPropertyReadHandler("count", async () => count);
+  thing.setActionHandler("increment", async () => { count += 1; return undefined; });
+  thing.setActionHandler("decrement", async () => { count -= 1; return undefined; });
+  thing.setActionHandler("reset", async () => { count = 0; return undefined; });
+
+  await thing.expose();
+  console.log("counter exposed at http://localhost:8080/counter");
+});


### PR DESCRIPTION
End-to-end demos: thingctx consumes TDs produced by node-wot and Eclipse Ditto. README Interoperability section.