### PR TITLE
chore(security): pre-commit hooks, gitleaks CI, SECURITY.md

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,47 @@
+name: security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    name: secret-scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so the scan covers every commit
+
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_CONFIG: .gitleaks.toml
+
+      - name: internal/private strings
+        # The forbidden list is provided out-of-band as a repo secret so the
+        # names never live in source. No secret configured => safe no-op.
+        env:
+          BANNED: ${{ secrets.BANNED_SUBSTRINGS }}
+        run: |
+          if [ -z "${BANNED}" ]; then
+            echo "BANNED_SUBSTRINGS not set; skipping internal-name guard."
+            exit 0
+          fi
+          mkdir -p .security
+          printf '%s\n' "${BANNED}" > .security/banned-substrings.txt
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=0 || true
+            scripts/check_no_internal_leaks.sh --range "origin/${{ github.base_ref }}...HEAD"
+          else
+            scripts/check_no_internal_leaks.sh --range "HEAD~1...HEAD"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,31 @@ __pycache__/
 dist/
 build/
 
-# Agent contract / internal instructions , never public
+# Logs and local scratch
+*.log
+node_modules/
+
+# Secrets and credentials -- never commit (a *.example template is fine)
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.pfx
+*.keystore
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+*service-account*.json
+*credentials*.json
+*-key.json
+.netrc
+.npmrc
+
+# Local-only security config (banned-substring list, etc.) -- never public
+.security/
+
+# Agent contract / internal instructions -- never public
 .claude/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,24 @@
+# gitleaks configuration. Extends the built-in ruleset and adds a narrow
+# allowlist for deterministic, non-secret test vectors so legitimate fixtures
+# do not block commits.
+title = "thingctx gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Non-secret fixtures and public test vectors"
+# Canonical AWS SigV4 example credentials from the AWS docs/test suite. These
+# are published, non-functional vectors used only to assert signing output.
+regexes = [
+  '''AKIDEXAMPLE''',
+  '''wJalrXUtnFEMI/K7MDENG\+bPxRfiCYEXAMPLEKEY''',
+]
+# Obvious placeholder tokens used in tests and examples.
+stopwords = [
+  "example",
+  "placeholder",
+  "changeme",
+  "dummy",
+  "test-token",
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# Run `pre-commit install` once to enable these on every commit.
+# See SECURITY.md for the full setup (including the local internal-name guard).
+minimum_pre_commit_version: "3.5.0"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files
+        args: ["--maxkb=512"]
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-yaml
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: debug-statements
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+
+  # Local guard: block internal/private strings. The forbidden list is NOT in
+  # this repo (it lives in a gitignored file); without it this hook is a no-op.
+  - repo: local
+    hooks:
+      - id: no-internal-leaks
+        name: no internal/private strings
+        entry: scripts/check_no_internal_leaks.sh
+        language: script
+        pass_filenames: true
+        require_serial: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately via GitHub Security Advisories
+("Report a vulnerability" on the Security tab) rather than opening a public
+issue. We aim to acknowledge reports within a few business days.
+
+## Secret-leak prevention
+
+This repo uses layered checks so credentials and other secrets never land in
+history.
+
+### 1. Local pre-commit hooks (contributors)
+
+Install once after cloning:
+
+```bash
+pipx install pre-commit   # or: pip install pre-commit / brew install pre-commit
+pre-commit install
+```
+
+On every commit this runs:
+
+- **gitleaks** — scans staged changes for tokens, keys, and high-entropy secrets.
+- **detect-private-key** and **check-added-large-files** — block private keys and
+  oversized blobs.
+- **ruff** (lint + format) — keeps style consistent with CI.
+
+Run against the whole tree at any time:
+
+```bash
+pre-commit run --all-files
+gitleaks detect --config .gitleaks.toml   # full-history scan
+```
+
+If a check is a genuine false positive (e.g. a public test vector), add a narrow
+allowlist entry in `.gitleaks.toml` rather than disabling the hook.
+
+### 2. CI scanning (every PR)
+
+`.github/workflows/security.yml` runs gitleaks over the full history on every
+push and pull request, independent of whether a contributor installed the local
+hooks.
+
+### 3. Maintainer guard for internal references
+
+A local, no-op-by-default hook (`scripts/check_no_internal_leaks.sh`) blocks
+commits that contain internal codenames or local machine paths. The forbidden
+list is deliberately **not** stored in this repo — keep it in a gitignored
+`.security/banned-substrings.txt` (one substring per line). In CI the same list
+is supplied out-of-band via the `BANNED_SUBSTRINGS` repository secret.
+
+### 4. GitHub repository settings (recommended)
+
+Enable these in **Settings → Code security** for the strongest backstop:
+
+- **Secret scanning** and **Push protection** — GitHub rejects pushes that
+  contain recognized secrets, before they ever reach a branch.
+- **Branch protection** on `main` — require the `ci-ok` and `secret-scan` checks
+  and a review before merge.

--- a/scripts/check_no_internal_leaks.sh
+++ b/scripts/check_no_internal_leaks.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Guard against committing internal/private strings (project codenames, local
+# machine paths, internal planning docs, ...) into this public repo.
+#
+# The list of forbidden substrings is intentionally NOT stored in this repo --
+# that would leak the very names we are hiding. It lives in a gitignored file
+# (.security/banned-substrings.txt) or is provided via $THINGCTX_BANNED_FILE.
+# When no list is present this hook is a safe no-op, so contributors without it
+# are unaffected while the maintainer's machine and CI stay protected.
+#
+# Usage:
+#   check_no_internal_leaks.sh [FILE ...]           scan the given files (pre-commit)
+#   check_no_internal_leaks.sh --range BASE...HEAD  scan added lines in a range (CI)
+set -euo pipefail
+
+SELF="scripts/check_no_internal_leaks.sh"
+
+# Resolve the banned-substring list, first match wins: an explicit override, a
+# per-repo gitignored file, then a machine-wide file (covers every clone and
+# worktree at once). Absent everywhere, this hook is a no-op.
+BANNED_FILE=""
+for cand in \
+  "${THINGCTX_BANNED_FILE:-}" \
+  ".security/banned-substrings.txt" \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/thingctx/banned-substrings.txt"; do
+  if [ -n "$cand" ] && [ -f "$cand" ]; then
+    BANNED_FILE="$cand"
+    break
+  fi
+done
+[ -n "$BANNED_FILE" ] || exit 0
+
+patterns="$(grep -vE '^[[:space:]]*(#|$)' "$BANNED_FILE" || true)"
+[ -n "$patterns" ] || exit 0
+
+status=0
+match() { grep -inF -f <(printf '%s\n' "$patterns") "$@"; }
+
+if [ "${1:-}" = "--range" ]; then
+  range="${2:?usage: --range BASE...HEAD}"
+  added="$(git diff "$range" -U0 -- . ":(exclude).security/**" ":(exclude)$SELF" \
+    | grep -E '^\+' || true)"
+  if printf '%s' "$added" | match >/dev/null 2>&1; then
+    echo "ERROR: internal/private string found in added lines:" >&2
+    printf '%s' "$added" | match >&2 || true
+    status=1
+  fi
+else
+  for f in "$@"; do
+    case "$f" in
+      .security/* | "$SELF") continue ;;
+    esac
+    [ -f "$f" ] || continue
+    if match "$f" >/dev/null 2>&1; then
+      echo "ERROR: internal/private string in $f:" >&2
+      match "$f" >&2 || true
+      status=1
+    fi
+  done
+fi
+
+if [ "$status" -ne 0 ]; then
+  echo "" >&2
+  echo "Commit blocked: remove the internal/private references above," >&2
+  echo "or update your local allowlist if this is a false positive." >&2
+fi
+exit "$status"


### PR DESCRIPTION
Layered secret-leak prevention.

- `.pre-commit-config.yaml`: gitleaks, detect-private-key, large-file guard, ruff, + a local no-op-by-default internal-name guard.
- `.github/workflows/security.yml`: gitleaks over full history on every push/PR.
- `scripts/check_no_internal_leaks.sh`: blocks internal codenames/paths from a gitignored list (never in-repo).
- `.gitignore`: credential files, keys, logs.
- `SECURITY.md`: reporting + setup.

After merge: add `secret-scan` as a required status check on `main`.