### PR TITLE
feat(lint): report whether an agent can use a TD

### DIFF
--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -86,6 +86,7 @@ from thingctx.contracts import implements
 from thingctx.contrib.llm import LLMHost
 
 # Compile a non-WoT description (OpenAPI) into a TD.
+from thingctx.lint import LintFinding, lint_td
 from thingctx.openapi import from_openapi, load_spec
 from thingctx.registry import (
     FileRegistry,
@@ -120,6 +121,8 @@ __all__ = [
     "from_td",
     "from_openapi",
     "load_spec",
+    "lint_td",
+    "LintFinding",
     "ThingClient",
     "LLMHost",
     "Registry",

--- a/src/thingctx/cli.py
+++ b/src/thingctx/cli.py
@@ -3,9 +3,11 @@
 """The ``thingctx`` command line.
 
     thingctx import openapi <spec> [--out td.json] [--base-url URL] [--id ID]
+    thingctx lint <td>
 
 ``<spec>`` is a file path or http(s) URL (JSON or YAML). With ``--out`` the TD
-is written there; otherwise it is printed to stdout.
+is written there; otherwise it is printed to stdout. ``lint`` reads a TD and
+reports whether an agent can use it; it exits 1 on any error-severity finding.
 """
 
 from __future__ import annotations
@@ -13,6 +15,28 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import urllib.request
+
+
+def _load_td(source: str) -> dict:
+    """Read one TD from a file path or an http(s) URL."""
+    if source.startswith(("http://", "https://")):
+        with urllib.request.urlopen(source) as resp:  # noqa: S310 (scheme checked above)
+            return json.loads(resp.read().decode("utf-8"))
+    with open(source, encoding="utf-8") as fh:
+        return json.loads(fh.read())
+
+
+def _cmd_lint(args: argparse.Namespace) -> int:
+    from .lint import lint_td
+
+    findings = lint_td(_load_td(args.td))
+    for f in findings:
+        print(f"{f.severity:6} {f.target}  [{f.rule}] {f.message}", file=sys.stderr)
+    errors = sum(1 for f in findings if f.severity == "error")
+    if not findings:
+        print("ok: no lint findings", file=sys.stderr)
+    return 1 if errors else 0
 
 
 def _cmd_import_openapi(args: argparse.Namespace) -> int:
@@ -43,6 +67,10 @@ def build_parser() -> argparse.ArgumentParser:
     oa.add_argument("--id", help="TD id (default: urn:thingctx:<title-slug>)")
     oa.add_argument("--title", help="Thing title (default: info.title)")
     oa.set_defaults(func=_cmd_import_openapi)
+
+    ln = sub.add_parser("lint", help="report whether an agent can use a TD")
+    ln.add_argument("td", help="Thing Description: file path or http(s) URL")
+    ln.set_defaults(func=_cmd_lint)
     return ap
 
 

--- a/src/thingctx/lint.py
+++ b/src/thingctx/lint.py
@@ -1,0 +1,271 @@
+# Copyright 2026 The thingctx Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Lint a Thing Description for whether an agent can use it.
+
+``validate_td`` answers whether a TD is legal against the W3C TD 1.1 schema.
+``lint_td`` answers a different question: once the TD is projected to tool
+specs (see ``docs/MAPPING.md``, which is normative for what a model sees), will
+a model be able to choose and call its affordances? A TD can be schema-valid and
+still project a tool with no description, no argument names, or a name the model
+providers reject.
+
+The linter reads one document, returns findings, and touches no network. It never
+rejects a valid TD; every finding is advice. Rule ids are stable ``snake_case``
+strings so a caller can filter or suppress by id.
+
+    from thingctx.lint import lint_td
+    for f in lint_td(td):
+        print(f.severity, f.target, f.rule, f.message)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# The tool-name charset the OpenAI/Anthropic function-calling APIs accept.
+# ``_tool_name`` in thing.py keeps ``. _ -`` in the slug; a name outside this
+# set is silently rejected by a provider at call time, so flag it here.
+_TOOL_NAME_OK = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+# The shape ``from_openapi`` emits when an operation has no ``operationId``:
+# a method and a path slug joined by an underscore (e.g. ``get_users_id``).
+_GENERATED_NAME = re.compile(r"^(get|post|put|patch|delete|head|options)_[a-z0-9_]+$", re.I)
+
+# A single word (no space) is almost never a usable description for a model.
+_SINGLE_TOKEN = re.compile(r"^\S+$")
+
+# Header names that carry a secret. A TD is meant to be committed and shared, so
+# a credential in ``htv:headers`` is the one thing the security posture forbids.
+_CREDENTIAL_HEADERS = {"authorization", "cookie", "proxy-authorization"}
+_CREDENTIAL_HINT = re.compile(r"(api[-_]?key|token|secret|password|bearer)", re.I)
+
+_MIN_DESCRIPTION = 8  # a description under this many characters carries no meaning
+
+
+@dataclass
+class LintFinding:
+    """One lint result. ``severity`` is "error" | "warn" | "notice";
+    ``target`` is a JSON-pointer-style path into the TD; ``rule`` is a stable
+    id; ``message`` states the problem in the reader's terms."""
+
+    severity: str
+    target: str
+    rule: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "severity": self.severity,
+            "target": self.target,
+            "rule": self.rule,
+            "message": self.message,
+        }
+
+
+def lint_td(td: dict[str, Any]) -> list[LintFinding]:
+    """Return findings for one TD, ordered by where they occur. Never raises on
+    a well-formed dict; a caller should still ``validate_td`` for legality."""
+    out: list[LintFinding] = []
+
+    _lint_id(td, out)
+    _lint_thing_type(td, out)
+
+    for kind in ("actions", "properties", "events"):
+        for name, aff in (td.get(kind) or {}).items():
+            if not isinstance(aff, dict):
+                continue
+            base = f"{kind}/{name}"
+            _lint_affordance_name(kind, name, base, out)
+            _lint_description(name, aff, base, out)
+            _lint_affordance_type(kind, aff, base, out)
+            _lint_headers(aff, base, out)
+        # per-kind detail below
+
+    for name, action in (td.get("actions") or {}).items():
+        if isinstance(action, dict):
+            _lint_action_risk(name, action, f"actions/{name}", out)
+            _lint_empty_input(name, action, f"actions/{name}", out)
+
+    for name, prop in (td.get("properties") or {}).items():
+        if isinstance(prop, dict):
+            _lint_property_units(name, prop, f"properties/{name}", out)
+
+    return out
+
+
+def _lint_id(td: dict[str, Any], out: list[LintFinding]) -> None:
+    tid = td.get("id") or td.get("@id")
+    if isinstance(tid, str) and tid.startswith(("http://", "https://")):
+        # ``_tool_name`` derives the tool-name prefix from the id's last path
+        # segment; a URL-shaped id can collapse or collide, mangling every tool.
+        out.append(
+            LintFinding(
+                "warn",
+                "id",
+                "url_shaped_id",
+                "id is a URL; the tool-name prefix is derived from its last path "
+                "segment and may collide. Prefer a urn: id.",
+            )
+        )
+
+
+def _lint_thing_type(td: dict[str, Any], out: list[LintFinding]) -> None:
+    if not td.get("@type"):
+        out.append(
+            LintFinding(
+                "notice",
+                "@type",
+                "missing_thing_type",
+                "Thing has no @type; W3C WoT Discovery typed search cannot find it.",
+            )
+        )
+
+
+def _lint_affordance_name(kind: str, name: str, base: str, out: list[LintFinding]) -> None:
+    if not _TOOL_NAME_OK.match(name):
+        out.append(
+            LintFinding(
+                "error",
+                base,
+                "invalid_tool_name",
+                f"{kind[:-1]} name {name!r} projects to a tool name outside the "
+                "accepted charset [A-Za-z0-9_.-]; the model provider will reject it.",
+            )
+        )
+    elif _GENERATED_NAME.match(name):
+        out.append(
+            LintFinding(
+                "warn",
+                base,
+                "generated_name",
+                f"{name!r} looks machine-generated (method plus path); a readable "
+                "name helps a model choose it.",
+            )
+        )
+
+
+def _lint_description(name: str, aff: dict[str, Any], base: str, out: list[LintFinding]) -> None:
+    # Projection precedence (thing.py): description, then title, then the bare
+    # name. If both are absent the model sees only the name.
+    desc = aff.get("description") or aff.get("title")
+    if not desc:
+        out.append(
+            LintFinding(
+                "warn",
+                base,
+                "thin_description",
+                "no description or title; the projected tool description falls back "
+                "to the bare name, which tells a model nothing about what it does.",
+            )
+        )
+        return
+    if desc == name:
+        out.append(
+            LintFinding(
+                "notice",
+                base,
+                "thin_description",
+                "description duplicates the name; it adds nothing a model can use.",
+            )
+        )
+    elif len(desc) < _MIN_DESCRIPTION or _SINGLE_TOKEN.match(desc):
+        out.append(
+            LintFinding(
+                "notice",
+                base,
+                "thin_description",
+                f"description {desc!r} is too short to guide a model.",
+            )
+        )
+
+
+def _lint_affordance_type(
+    kind: str, aff: dict[str, Any], base: str, out: list[LintFinding]
+) -> None:
+    if not aff.get("@type"):
+        out.append(
+            LintFinding(
+                "notice",
+                base,
+                "missing_affordance_type",
+                "no @type; a class term makes the affordance groupable and findable "
+                "in W3C WoT Discovery typed search.",
+            )
+        )
+
+
+def _lint_action_risk(name: str, action: dict[str, Any], base: str, out: list[LintFinding]) -> None:
+    # thing.py treats an action as idempotent when either ``safe`` or
+    # ``idempotent`` is set; the trust gate must otherwise assume worst case.
+    safe = action.get("safe")
+    idem = action.get("idempotent")
+    at_type = action.get("@type")
+    marks = " ".join(at_type) if isinstance(at_type, list | tuple) else str(at_type or "")
+    has_tc_mark = "tc:" in marks or "requiresApproval" in action
+    if safe is None and idem is None and not has_tc_mark:
+        out.append(
+            LintFinding(
+                "notice",
+                base,
+                "unmarked_risk",
+                "no safe/idempotent flag and no tc: risk marking; the approval gate "
+                "must assume this action is destructive on every call.",
+            )
+        )
+
+
+def _lint_empty_input(name: str, action: dict[str, Any], base: str, out: list[LintFinding]) -> None:
+    inp = action.get("input")
+    if not isinstance(inp, dict):
+        return
+    if inp.get("type") == "object" and not inp.get("properties"):
+        out.append(
+            LintFinding(
+                "warn",
+                f"{base}/input",
+                "empty_parameters",
+                "input is an object with no properties; the model gets no argument "
+                "names and cannot form a call.",
+            )
+        )
+
+
+def _lint_property_units(
+    name: str, prop: dict[str, Any], base: str, out: list[LintFinding]
+) -> None:
+    if prop.get("type") in ("number", "integer") and not prop.get("unit") and not prop.get("@type"):
+        out.append(
+            LintFinding(
+                "notice",
+                base,
+                "missing_units",
+                "numeric property has no unit and no @type; a model must guess what "
+                "the number measures.",
+            )
+        )
+
+
+def _lint_headers(aff: dict[str, Any], base: str, out: list[LintFinding]) -> None:
+    for i, form in enumerate(aff.get("forms") or []):
+        if not isinstance(form, dict):
+            continue
+        headers = form.get("htv:headers")
+        if not isinstance(headers, list):
+            continue
+        for h in headers:
+            if not isinstance(h, dict):
+                continue
+            field = str(h.get("htv:fieldName", ""))
+            low = field.lower()
+            if low in _CREDENTIAL_HEADERS or _CREDENTIAL_HINT.search(low):
+                out.append(
+                    LintFinding(
+                        "error",
+                        f"{base}/forms/{i}",
+                        "credential_in_td",
+                        f"form header {field!r} looks like a credential; a TD is meant "
+                        "to be shared and must carry no secret. The invoker holds secrets.",
+                    )
+                )

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,143 @@
+# Copyright 2026 The thingctx Authors
+# SPDX-License-Identifier: Apache-2.0
+"""lint_td flags the ways a schema-valid TD still fails an agent, and never
+rejects a clean one. All offline: TDs are built inline."""
+
+from __future__ import annotations
+
+from thingctx.lint import lint_td
+
+
+def _rules(td: dict) -> set[str]:
+    return {f.rule for f in lint_td(td)}
+
+
+def test_a_clean_td_produces_no_findings():
+    td = {
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "@type": "saref:Pump",
+        "id": "urn:demo:pump:v1",
+        "title": "Pump",
+        "properties": {
+            "rpm": {
+                "@type": "saref:Speed",
+                "title": "Speed",
+                "description": "Current rotational speed.",
+                "type": "number",
+                "unit": "rpm",
+                "readOnly": True,
+                "forms": [{"href": "https://d/rpm"}],
+            }
+        },
+        "actions": {
+            "set_speed": {
+                "@type": "saref:SetLevelCommand",
+                "description": "Set the target rotational speed of the pump.",
+                "safe": False,
+                "idempotent": True,
+                "input": {"type": "object", "properties": {"rpm": {"type": "number"}}},
+                "forms": [{"href": "https://d/set", "htv:methodName": "POST"}],
+            }
+        },
+    }
+    assert lint_td(td) == []
+
+
+def test_thin_description_and_generated_name():
+    td = {
+        "id": "urn:demo:x",
+        "title": "X",
+        "actions": {
+            # no description, no title -> thin; name looks importer-generated
+            "get_users_id": {"forms": [{"href": "https://d/u"}]},
+        },
+    }
+    rules = _rules(td)
+    assert "thin_description" in rules
+    assert "generated_name" in rules
+
+
+def test_invalid_tool_name_is_an_error():
+    td = {
+        "id": "urn:demo:x",
+        "title": "X",
+        # a slash-shaped name (GitHub-style) is outside the accepted charset
+        "actions": {"repos/get": {"description": "Get a repo.", "forms": [{"href": "https://d"}]}},
+    }
+    findings = lint_td(td)
+    assert any(f.rule == "invalid_tool_name" and f.severity == "error" for f in findings)
+
+
+def test_empty_parameters_flagged():
+    td = {
+        "id": "urn:demo:x",
+        "title": "X",
+        "actions": {
+            "do_it": {
+                "description": "Do the thing now.",
+                "safe": True,
+                "input": {"type": "object"},  # object, no properties
+                "forms": [{"href": "https://d"}],
+            }
+        },
+    }
+    assert "empty_parameters" in _rules(td)
+
+
+def test_credential_shaped_header_is_an_error():
+    td = {
+        "id": "urn:demo:x",
+        "title": "X",
+        "actions": {
+            "call": {
+                "description": "Call the endpoint.",
+                "safe": True,
+                "forms": [
+                    {
+                        "href": "https://d",
+                        "htv:headers": [
+                            {"htv:fieldName": "Authorization", "htv:fieldValue": "Bearer x"}
+                        ],
+                    }
+                ],
+            }
+        },
+    }
+    findings = lint_td(td)
+    assert any(f.rule == "credential_in_td" and f.severity == "error" for f in findings)
+
+
+def test_url_shaped_id_and_missing_types():
+    td = {
+        "id": "https://example.com/things/pump",  # url-shaped
+        "title": "Pump",  # no @type on the Thing
+        "properties": {
+            "temp": {
+                "description": "Temperature.",
+                "type": "number",
+                "forms": [{"href": "https://d"}],
+            }
+        },
+    }
+    rules = _rules(td)
+    assert "url_shaped_id" in rules
+    assert "missing_thing_type" in rules
+    assert "missing_units" in rules  # numeric, no unit, no @type
+    assert "missing_affordance_type" in rules
+
+
+def test_unmarked_risk_notice():
+    td = {
+        "id": "urn:demo:x",
+        "title": "X",
+        "actions": {
+            # no safe, no idempotent, no tc: marking
+            "reboot": {"description": "Reboot the device.", "forms": [{"href": "https://d"}]}
+        },
+    }
+    assert "unmarked_risk" in _rules(td)
+
+
+def test_findings_are_advice_never_an_exception():
+    # a sparse but well-formed dict lints without raising
+    assert isinstance(lint_td({"id": "urn:x", "title": "X"}), list)


### PR DESCRIPTION
Adds `lint_td` and a `thingctx lint` CLI.

`validate_td` says a TD is legal against the W3C TD 1.1 schema. `lint_td` answers
a different question: once the TD is projected to tool specs (per `docs/MAPPING.md`),
can a model choose and call its affordances? A TD can be schema-valid and still
project a tool with no description, no argument names, or a name a provider rejects.

Rules v1 (each checkable against the projection): `thin_description`,
`generated_name`, `invalid_tool_name`, `empty_parameters`, `unmarked_risk`,
`missing_thing_type`, `missing_affordance_type`, `missing_units`, `url_shaped_id`,
`credential_in_td` (a secret never belongs in a shared TD).

- Reads one document; no network; no new required deps (stdlib only).
- Never rejects a valid TD; every finding is advice. Rule ids are stable
  `snake_case` so a caller can filter or suppress.
- `thingctx lint <td|url>` exits 1 on any error-severity finding, else 0.

8 tests, all offline. Implements #25.
