### PR TITLE
refactor(lint): reuse _tool_name and tighten thin_namespace check

### DIFF
--- a/src/thingctx/lint.py
+++ b/src/thingctx/lint.py
@@ -24,6 +24,8 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from thingctx.thing import _tool_name
+
 # The tool-name charset the OpenAI/Anthropic function-calling APIs accept.
 # ``_tool_name`` in thing.py keeps ``. _ -`` in the slug; a name outside this
 # set is silently rejected by a provider at call time, so flag it here.
@@ -40,6 +42,12 @@ _SINGLE_TOKEN = re.compile(r"^\S+$")
 # a credential in ``htv:headers`` is the one thing the security posture forbids.
 _CREDENTIAL_HEADERS = {"authorization", "cookie", "proxy-authorization"}
 _CREDENTIAL_HINT = re.compile(r"(api[-_]?key|token|secret|password|bearer)", re.I)
+
+# Namespace slugs that are too thin to help a model group tools.
+# Single-letter slugs are always unusable. ``t1``, ``x999``, ``a1`` are
+# clearly placeholder- or example-shaped. Deliberately conservative:
+# a short but meaningful abbreviation like ``db`` is not flagged.
+_THIN_NAMESPACE = re.compile(r"^(?:[a-z]\d?|[tx]\d+)$", re.I)
 
 _MIN_DESCRIPTION = 8  # a description under this many characters carries no meaning
 
@@ -97,13 +105,9 @@ def lint_td(td: dict[str, Any]) -> list[LintFinding]:
 
 
 def _slug_from_id(thing_id: str) -> str:
-    """Extract the namespace slug from a Thing id (same logic as
-    ``_tool_name`` in thing.py)."""
-    parts = [p for p in str(thing_id).split(":") if p]
-    if len(parts) >= 2 and parts[-1].lower().lstrip("v").isdigit():
-        parts = parts[:-1]
-    slug = parts[-1] if parts else str(thing_id)
-    return "".join(c if (c.isalnum() or c in "._-") else "-" for c in slug)
+    """Extract the namespace slug from a Thing id (delegates to
+    ``_tool_name`` in thing.py for the canonical slug logic)."""
+    return _tool_name(thing_id, "_").rsplit(".", 1)[0]
 
 
 def _lint_id(td: dict[str, Any], out: list[LintFinding]) -> None:
@@ -127,14 +131,15 @@ def _lint_thin_namespace(td: dict[str, Any], out: list[LintFinding]) -> None:
     if not isinstance(tid, str):
         return
     slug = _slug_from_id(tid)
-    if len(slug) <= 2:
+    if len(slug) == 1 or _THIN_NAMESPACE.match(slug):
         out.append(
             LintFinding(
                 "notice",
                 "id",
                 "thin_namespace",
-                f"Thing id {tid!r} projects to a {len(slug)}-character namespace "
-                f"({slug!r}); a model cannot group tools by a namespace this short.",
+                f"Thing id {tid!r} projects to a thin namespace {slug!r}; a model "
+                "cannot group tools by a namespace this short. Prefer a meaningful "
+                "device or service id.",
             )
         )
 

--- a/src/thingctx/lint.py
+++ b/src/thingctx/lint.py
@@ -70,6 +70,7 @@ def lint_td(td: dict[str, Any]) -> list[LintFinding]:
     out: list[LintFinding] = []
 
     _lint_id(td, out)
+    _lint_thin_namespace(td, out)
     _lint_thing_type(td, out)
 
     for kind in ("actions", "properties", "events"):
@@ -95,6 +96,16 @@ def lint_td(td: dict[str, Any]) -> list[LintFinding]:
     return out
 
 
+def _slug_from_id(thing_id: str) -> str:
+    """Extract the namespace slug from a Thing id (same logic as
+    ``_tool_name`` in thing.py)."""
+    parts = [p for p in str(thing_id).split(":") if p]
+    if len(parts) >= 2 and parts[-1].lower().lstrip("v").isdigit():
+        parts = parts[:-1]
+    slug = parts[-1] if parts else str(thing_id)
+    return "".join(c if (c.isalnum() or c in "._-") else "-" for c in slug)
+
+
 def _lint_id(td: dict[str, Any], out: list[LintFinding]) -> None:
     tid = td.get("id") or td.get("@id")
     if isinstance(tid, str) and tid.startswith(("http://", "https://")):
@@ -107,6 +118,23 @@ def _lint_id(td: dict[str, Any], out: list[LintFinding]) -> None:
                 "url_shaped_id",
                 "id is a URL; the tool-name prefix is derived from its last path "
                 "segment and may collide. Prefer a urn: id.",
+            )
+        )
+
+
+def _lint_thin_namespace(td: dict[str, Any], out: list[LintFinding]) -> None:
+    tid = td.get("id") or td.get("@id")
+    if not isinstance(tid, str):
+        return
+    slug = _slug_from_id(tid)
+    if len(slug) <= 2:
+        out.append(
+            LintFinding(
+                "notice",
+                "id",
+                "thin_namespace",
+                f"Thing id {tid!r} projects to a {len(slug)}-character namespace "
+                f"({slug!r}); a model cannot group tools by a namespace this short.",
             )
         )
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -184,6 +184,23 @@ def test_thin_namespace_flagged_for_two_char_id():
     assert "thin_namespace" in _rules(td)
 
 
+def test_thin_namespace_does_not_flag_meaningful_short_name():
+    td = {
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "@type": "saref:Pump",
+        "id": "urn:demo:db:v1",
+        "title": "Database",
+        "actions": {
+            "query": {
+                "description": "Run a query.",
+                "safe": True,
+                "forms": [{"href": "https://d/query"}],
+            }
+        },
+    }
+    assert "thin_namespace" not in _rules(td)
+
+
 def test_findings_are_advice_never_an_exception():
     # a sparse but well-formed dict lints without raising
     assert isinstance(lint_td({"id": "urn:myapp", "title": "MyApp"}), list)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -45,8 +45,8 @@ def test_a_clean_td_produces_no_findings():
 
 def test_thin_description_and_generated_name():
     td = {
-        "id": "urn:demo:x",
-        "title": "X",
+        "id": "urn:demo:myapp",
+        "title": "MyApp",
         "actions": {
             # no description, no title -> thin; name looks importer-generated
             "get_users_id": {"forms": [{"href": "https://d/u"}]},
@@ -59,8 +59,8 @@ def test_thin_description_and_generated_name():
 
 def test_invalid_tool_name_is_an_error():
     td = {
-        "id": "urn:demo:x",
-        "title": "X",
+        "id": "urn:demo:myapp",
+        "title": "MyApp",
         # a slash-shaped name (GitHub-style) is outside the accepted charset
         "actions": {"repos/get": {"description": "Get a repo.", "forms": [{"href": "https://d"}]}},
     }
@@ -70,8 +70,8 @@ def test_invalid_tool_name_is_an_error():
 
 def test_empty_parameters_flagged():
     td = {
-        "id": "urn:demo:x",
-        "title": "X",
+        "id": "urn:demo:myapp",
+        "title": "MyApp",
         "actions": {
             "do_it": {
                 "description": "Do the thing now.",
@@ -86,8 +86,8 @@ def test_empty_parameters_flagged():
 
 def test_credential_shaped_header_is_an_error():
     td = {
-        "id": "urn:demo:x",
-        "title": "X",
+        "id": "urn:demo:myapp",
+        "title": "MyApp",
         "actions": {
             "call": {
                 "description": "Call the endpoint.",
@@ -128,8 +128,8 @@ def test_url_shaped_id_and_missing_types():
 
 def test_unmarked_risk_notice():
     td = {
-        "id": "urn:demo:x",
-        "title": "X",
+        "id": "urn:demo:myapp",
+        "title": "MyApp",
         "actions": {
             # no safe, no idempotent, no tc: marking
             "reboot": {"description": "Reboot the device.", "forms": [{"href": "https://d"}]}
@@ -138,6 +138,52 @@ def test_unmarked_risk_notice():
     assert "unmarked_risk" in _rules(td)
 
 
+def test_thin_namespace_flagged_for_short_id():
+    td = {
+        "id": "x",
+        "title": "X",
+        "actions": {
+            "do_it": {
+                "description": "Do the thing.",
+                "safe": True,
+                "forms": [{"href": "https://d"}],
+            }
+        },
+    }
+    rules = _rules(td)
+    assert "thin_namespace" in rules
+
+
+def test_thin_namespace_clean_for_normal_id():
+    td = {
+        "id": "urn:demo:pump:v1",
+        "title": "Pump",
+        "actions": {
+            "set_speed": {
+                "description": "Set the speed.",
+                "safe": True,
+                "forms": [{"href": "https://d"}],
+            }
+        },
+    }
+    assert "thin_namespace" not in _rules(td)
+
+
+def test_thin_namespace_flagged_for_two_char_id():
+    td = {
+        "id": "urn:t1",
+        "title": "T1",
+        "actions": {
+            "read": {
+                "description": "Read value.",
+                "safe": True,
+                "forms": [{"href": "https://d"}],
+            }
+        },
+    }
+    assert "thin_namespace" in _rules(td)
+
+
 def test_findings_are_advice_never_an_exception():
     # a sparse but well-formed dict lints without raising
-    assert isinstance(lint_td({"id": "urn:x", "title": "X"}), list)
+    assert isinstance(lint_td({"id": "urn:myapp", "title": "MyApp"}), list)


### PR DESCRIPTION
Reconciles PR #36 (this PR, now updated) and PR #37 (superseded) for issue #35.

Changes since the initial merge:
- `_slug_from_id` now delegates to `_tool_name` (thing.py) instead of duplicating its slice/join/sanitize logic — eliminates the maintenance debt of keeping two identical slug extractors in sync
- Replaces the broad `len(slug) <= 2` check with `_THIN_NAMESPACE` regex that flags placeholder-shaped namespaces (single letter, `t1`, `x999`, `a1`) but lets meaningful short names like `db` pass
- Keeps the check per-Thing (not per-affordance as PR #37 did) to avoid redundant notices
- Adds test: `db` (a meaningful 2-char abbreviation) is not flagged

Closes #35.