### PR TITLE
feat: warn on thin tool namespaces

### DIFF
--- a/src/thingctx/lint.py
+++ b/src/thingctx/lint.py
@@ -24,6 +24,8 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from thingctx.thing import _tool_name
+
 # The tool-name charset the OpenAI/Anthropic function-calling APIs accept.
 # ``_tool_name`` in thing.py keeps ``. _ -`` in the slug; a name outside this
 # set is silently rejected by a provider at call time, so flag it here.
@@ -40,6 +42,7 @@ _SINGLE_TOKEN = re.compile(r"^\S+$")
 # a credential in ``htv:headers`` is the one thing the security posture forbids.
 _CREDENTIAL_HEADERS = {"authorization", "cookie", "proxy-authorization"}
 _CREDENTIAL_HINT = re.compile(r"(api[-_]?key|token|secret|password|bearer)", re.I)
+_THIN_NAMESPACE = re.compile(r"^(?:[a-z]\d?|[tx]\d+)$", re.I)
 
 _MIN_DESCRIPTION = 8  # a description under this many characters carries no meaning
 
@@ -71,6 +74,7 @@ def lint_td(td: dict[str, Any]) -> list[LintFinding]:
 
     _lint_id(td, out)
     _lint_thing_type(td, out)
+    _lint_tool_namespace(td, out)
 
     for kind in ("actions", "properties", "events"):
         for name, aff in (td.get(kind) or {}).items():
@@ -121,6 +125,25 @@ def _lint_thing_type(td: dict[str, Any], out: list[LintFinding]) -> None:
                 "Thing has no @type; W3C WoT Discovery typed search cannot find it.",
             )
         )
+
+
+def _lint_tool_namespace(td: dict[str, Any], out: list[LintFinding]) -> None:
+    tid = td.get("id") or td.get("@id") or td.get("title", "thing")
+    for kind in ("actions", "properties", "events"):
+        for name, aff in (td.get(kind) or {}).items():
+            if not isinstance(aff, dict):
+                continue
+            namespace = _tool_name(tid, name).split(".", 1)[0]
+            if len(namespace) == 1 or _THIN_NAMESPACE.match(namespace):
+                out.append(
+                    LintFinding(
+                        "notice",
+                        f"{kind}/{name}",
+                        "thin_namespace",
+                        f"projected tool namespace {namespace!r} is too thin to help a model "
+                        "group this Thing's tools. Prefer a meaningful device or service id.",
+                    )
+                )
 
 
 def _lint_affordance_name(kind: str, name: str, base: str, out: list[LintFinding]) -> None:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -68,6 +68,44 @@ def test_invalid_tool_name_is_an_error():
     assert any(f.rule == "invalid_tool_name" and f.severity == "error" for f in findings)
 
 
+def test_thin_namespace_notice_for_opaque_thing_id():
+    for thing_id in ("urn:demo:x", "urn:demo:t1"):
+        td = {
+            "@context": "https://www.w3.org/2022/wot/td/v1.1",
+            "@type": "saref:Device",
+            "id": thing_id,
+            "title": "Opaque device",
+            "actions": {
+                "set_speed": {
+                    "@type": "saref:SetLevelCommand",
+                    "description": "Set the target rotational speed.",
+                    "safe": True,
+                    "forms": [{"href": "https://d/set"}],
+                }
+            },
+        }
+        findings = lint_td(td)
+        assert any(f.rule == "thin_namespace" and f.severity == "notice" for f in findings)
+
+
+def test_thin_namespace_does_not_flag_meaningful_short_names():
+    td = {
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "@type": "saref:Pump",
+        "id": "urn:demo:db:v1",
+        "title": "Pump",
+        "actions": {
+            "set_speed": {
+                "@type": "saref:SetLevelCommand",
+                "description": "Set the target rotational speed.",
+                "safe": True,
+                "forms": [{"href": "https://d/set"}],
+            }
+        },
+    }
+    assert "thin_namespace" not in _rules(td)
+
+
 def test_empty_parameters_flagged():
     td = {
         "id": "urn:demo:x",


### PR DESCRIPTION
## Summary
- add a `thin_namespace` lint notice for projected tool namespaces that are clearly too opaque to help model tool grouping
- reuse the real `_tool_name()` projection when checking namespace quality
- cover both opaque examples (`x`, `t1`) and a short meaningful namespace (`db`) in lint tests

Closes #35.

## Checks
- .venv/bin/python -m pytest tests/test_lint.py
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check src/thingctx/lint.py tests/test_lint.py