### PR TITLE
Refuse unreadable inputs in two gates, and move to mypy 2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ all = ["litellm>=1.0", "httpx>=0.27", "paho-mqtt>=2.0", "jsonschema>=4.0", "mcp>
 # botocore is here only as an independent oracle for the SigV4 signer: the test
 # compares our signature against botocore's canonical one. Without it installed
 # that comparison skips, so the signing code goes unchecked.
-dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.0", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==1.14.1", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13"]
+dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.0", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13"]
 
 [project.scripts]
 # Serve a Thing (or a whole fleet of TDs) to any MCP client.

--- a/src/thingctx/identity/jwt_guard.py
+++ b/src/thingctx/identity/jwt_guard.py
@@ -23,12 +23,26 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeGuard
 
 __all__ = ["AuthorizationError", "Grant", "JwtGatewayGuard"]
 
 _JWKS_TTL = 3600.0  # cache the provider's signing keys for an hour
 _JWKS_FORCE_COOLDOWN = 30.0  # min seconds between forced refetches (rotation), a DoS guard
+
+
+def _is_usable_jwks(jwks: object) -> TypeGuard[dict[str, Any]]:
+    """Whether ``jwks`` can actually be searched for a signing key.
+
+    Checked at both doors, the constructor's static jwks and a fetched response,
+    because ``_signing_key`` indexes into the entries and anything short of this
+    raises from inside it, past the fail-closed boundary the guard promises. An
+    empty key set is unusable too: it verifies nothing and would only wedge the
+    caller until it is replaced."""
+    if not isinstance(jwks, dict):
+        return False
+    keys = jwks.get("keys")
+    return bool(keys) and isinstance(keys, list) and all(isinstance(k, dict) for k in keys)
 
 
 class AuthorizationError(Exception):
@@ -134,6 +148,8 @@ class JwtGatewayGuard:
             raise ValueError("audience is required")
         if jwks is None and not jwks_url:
             raise ValueError("either jwks_url or a static jwks is required")
+        if jwks is not None and not _is_usable_jwks(jwks):
+            raise ValueError("the static jwks must be an object with a non-empty list of keys")
         self._issuers = issuers
         self.audience = str(audience)
         self.grants = tuple(grants)
@@ -186,11 +202,8 @@ class JwtGatewayGuard:
         # from inside _signing_key, past this guard's fail-closed boundary, which
         # surfaces as a 500 rather than the 401 it promises. Both levels matter,
         # because a str "keys" iterates into characters before it fails.
-        if not isinstance(jwks, dict):
-            raise AuthorizationError("the signing key endpoint did not return a JWKS object")
-        keys = jwks.get("keys")
-        if not keys or not isinstance(keys, list) or not all(isinstance(k, dict) for k in keys):
-            raise AuthorizationError("the signing key endpoint returned no usable key list")
+        if not _is_usable_jwks(jwks):
+            raise AuthorizationError("the signing key endpoint returned no usable key set")
         self._jwks_cache = jwks
         self._jwks_fetched_at = time.time()
         return jwks

--- a/src/thingctx/identity/jwt_guard.py
+++ b/src/thingctx/identity/jwt_guard.py
@@ -181,9 +181,15 @@ class JwtGatewayGuard:
             raise AuthorizationError(
                 "could not fetch the signing keys to verify the token"
             ) from exc
+        # A 2xx says nothing about the shape. Check before caching: a provider that
+        # answers a bare list wedges the cache for the whole TTL, and every later
+        # lookup then raises AttributeError past the fail-closed boundary, which
+        # surfaces as a 500 rather than the 401 this guard promises.
+        if not isinstance(jwks, dict):
+            raise AuthorizationError("the signing key endpoint did not return a JWKS object")
         self._jwks_cache = jwks
         self._jwks_fetched_at = time.time()
-        return self._jwks_cache  # type: ignore[return-value]
+        return jwks
 
     def _signing_key(self, jwks: dict[str, Any], kid: str | None) -> Any:
         """Build a public key for the token's ``kid`` from the JWKS, or raise."""

--- a/src/thingctx/identity/jwt_guard.py
+++ b/src/thingctx/identity/jwt_guard.py
@@ -186,10 +186,11 @@ class JwtGatewayGuard:
         # from inside _signing_key, past this guard's fail-closed boundary, which
         # surfaces as a 500 rather than the 401 it promises. Both levels matter,
         # because a str "keys" iterates into characters before it fails.
-        if not isinstance(jwks, dict) or not isinstance(jwks.get("keys"), list):
-            raise AuthorizationError(
-                "the signing key endpoint did not return a JWKS object with a key list"
-            )
+        if not isinstance(jwks, dict):
+            raise AuthorizationError("the signing key endpoint did not return a JWKS object")
+        keys = jwks.get("keys")
+        if not isinstance(keys, list) or not all(isinstance(k, dict) for k in keys):
+            raise AuthorizationError("the signing key endpoint returned no usable key list")
         self._jwks_cache = jwks
         self._jwks_fetched_at = time.time()
         return jwks

--- a/src/thingctx/identity/jwt_guard.py
+++ b/src/thingctx/identity/jwt_guard.py
@@ -189,7 +189,7 @@ class JwtGatewayGuard:
         if not isinstance(jwks, dict):
             raise AuthorizationError("the signing key endpoint did not return a JWKS object")
         keys = jwks.get("keys")
-        if not isinstance(keys, list) or not all(isinstance(k, dict) for k in keys):
+        if not keys or not isinstance(keys, list) or not all(isinstance(k, dict) for k in keys):
             raise AuthorizationError("the signing key endpoint returned no usable key list")
         self._jwks_cache = jwks
         self._jwks_fetched_at = time.time()

--- a/src/thingctx/identity/jwt_guard.py
+++ b/src/thingctx/identity/jwt_guard.py
@@ -181,12 +181,15 @@ class JwtGatewayGuard:
             raise AuthorizationError(
                 "could not fetch the signing keys to verify the token"
             ) from exc
-        # A 2xx says nothing about the shape. Check before caching: a provider that
-        # answers a bare list wedges the cache for the whole TTL, and every later
-        # lookup then raises AttributeError past the fail-closed boundary, which
-        # surfaces as a 500 rather than the 401 this guard promises.
-        if not isinstance(jwks, dict):
-            raise AuthorizationError("the signing key endpoint did not return a JWKS object")
+        # A 2xx says nothing about the shape. Check before caching: a bad shape
+        # wedges the cache for the whole TTL, and every later lookup then raises
+        # from inside _signing_key, past this guard's fail-closed boundary, which
+        # surfaces as a 500 rather than the 401 it promises. Both levels matter,
+        # because a str "keys" iterates into characters before it fails.
+        if not isinstance(jwks, dict) or not isinstance(jwks.get("keys"), list):
+            raise AuthorizationError(
+                "the signing key endpoint did not return a JWKS object with a key list"
+            )
         self._jwks_cache = jwks
         self._jwks_fetched_at = time.time()
         return jwks

--- a/src/thingctx/integrations/mcp.py
+++ b/src/thingctx/integrations/mcp.py
@@ -317,7 +317,7 @@ def build_mcp_server(
     # captured as an image. In gateway mode it gets its own verb so the surface
     # stays consistent (one shape for every affordance), instead of a per-Thing
     # <slug>__snapshot tool the model must cross over to.
-    _snapshot_verb = {
+    _snapshot_verb: dict[str, Any] = {
         "type": "function",
         "function": {
             "name": "snapshot",
@@ -352,7 +352,7 @@ def build_mcp_server(
     # action can't be confirmed by an elicitation dialog, the bridge parks it and
     # returns a token; the user says "yes" and the agent calls approve(token) to
     # run it. Present unless the approval gate is off (approve_when="never").
-    _approve_tool = {
+    _approve_tool: dict[str, Any] = {
         "type": "function",
         "function": {
             "name": "approve",

--- a/src/thingctx/netpolicy.py
+++ b/src/thingctx/netpolicy.py
@@ -98,19 +98,41 @@ def is_private_host(host: str) -> bool:
     )
 
 
+def _resolved_addrs(host: str) -> list[str]:
+    """The addresses ``host`` resolves to, as IP strings.
+
+    A sockaddr is family shaped: AF_INET and AF_INET6 start with the address
+    string, while a family the socket module does not model arrives as
+    ``(sa_family, raw_bytes)``. An entry carrying no address string cannot be
+    judged by :func:`is_private_host`, so it is refused rather than skipped:
+    this is the SSRF gate, and an answer that cannot be read must not read as
+    public. Propagates ``OSError`` from ``getaddrinfo``; each caller sets its
+    own policy for a failed resolution."""
+    addrs: list[str] = []
+    for info in socket.getaddrinfo(host, None):
+        addr = info[4][0]
+        if not isinstance(addr, str):
+            raise PolicyError(f"host {host!r} resolved to an unreadable address entry")
+        addrs.append(addr)
+    return addrs
+
+
 def resolve_is_private(host: str) -> bool:
     """Like :func:`is_private_host`, but resolves a hostname first and returns
     ``True`` if any resolved address is private.
 
     A resolution failure is treated as not-private; the connection attempt will
-    fail on its own."""
+    fail on its own. An address the policy cannot read is treated as private,
+    since it cannot be shown to be public."""
     if is_private_host(host):
         return True
     try:
-        infos = socket.getaddrinfo(host, None)
+        addrs = _resolved_addrs(host)
     except OSError:
         return False
-    return any(is_private_host(ai[4][0]) for ai in infos)
+    except PolicyError:
+        return True
+    return any(is_private_host(addr) for addr in addrs)
 
 
 def resolve_and_pin(host: str, *, what: str = "URL") -> str:
@@ -139,10 +161,9 @@ def resolve_and_pin(host: str, *, what: str = "URL") -> str:
         # A literal IP: already validated as public above; connect to it directly.
         return host
     try:
-        infos = socket.getaddrinfo(host, None)
+        addrs = _resolved_addrs(host)
     except OSError as exc:
         raise PolicyError(f"{what} host {host!r} could not be resolved") from exc
-    addrs = [ai[4][0] for ai in infos]
     if not addrs:
         raise PolicyError(f"{what} host {host!r} resolved to no address")
     # Every resolved address must be public: a name that answers both a public and

--- a/src/thingctx/netpolicy.py
+++ b/src/thingctx/netpolicy.py
@@ -110,11 +110,17 @@ def _resolved_addrs(host: str) -> list[str]:
     own policy for a failed resolution."""
     addrs: list[str] = []
     for info in socket.getaddrinfo(host, None):
-        addr = info[4][0]
-        # Must be a string AND parse as an IP. A str that is not an address, say a
-        # name a patched resolver handed back, would sail through is_private_host
-        # as "not private" and read as public, which is the failure this whole
-        # function exists to prevent.
+        # Shape first: a resolver that answers a short tuple would raise IndexError
+        # straight past this function, and an exception that is not PolicyError
+        # skips the fail-closed handling every caller wrote for it.
+        try:
+            addr = info[4][0]
+        except (TypeError, IndexError, KeyError) as exc:
+            raise PolicyError(f"host {host!r} resolved to an unreadable address entry") from exc
+        # Then content: it must be a string AND parse as an IP. A str that is not an
+        # address, say a name a patched resolver handed back, would sail through
+        # is_private_host as "not private" and read as public, which is the failure
+        # this whole function exists to prevent.
         if not isinstance(addr, str) or _as_ip(addr) is None:
             raise PolicyError(f"host {host!r} resolved to an unreadable address entry")
         addrs.append(addr)

--- a/src/thingctx/netpolicy.py
+++ b/src/thingctx/netpolicy.py
@@ -111,7 +111,11 @@ def _resolved_addrs(host: str) -> list[str]:
     addrs: list[str] = []
     for info in socket.getaddrinfo(host, None):
         addr = info[4][0]
-        if not isinstance(addr, str):
+        # Must be a string AND parse as an IP. A str that is not an address, say a
+        # name a patched resolver handed back, would sail through is_private_host
+        # as "not private" and read as public, which is the failure this whole
+        # function exists to prevent.
+        if not isinstance(addr, str) or _as_ip(addr) is None:
             raise PolicyError(f"host {host!r} resolved to an unreadable address entry")
         addrs.append(addr)
     return addrs

--- a/src/thingctx/netpolicy.py
+++ b/src/thingctx/netpolicy.py
@@ -110,9 +110,9 @@ def _resolved_addrs(host: str) -> list[str]:
     own policy for a failed resolution."""
     addrs: list[str] = []
     for info in socket.getaddrinfo(host, None):
-        # Shape first: a resolver that answers a short tuple would raise IndexError
-        # straight past this function, and an exception that is not PolicyError
-        # skips the fail-closed handling every caller wrote for it.
+        # Shape first. A resolver answering a short tuple raises IndexError here,
+        # and an exception that is not PolicyError would skip the fail-closed
+        # handling every caller wrote, so it is converted rather than allowed out.
         try:
             addr = info[4][0]
         except (TypeError, IndexError, KeyError) as exc:

--- a/src/thingctx/netpolicy.py
+++ b/src/thingctx/netpolicy.py
@@ -164,6 +164,10 @@ def resolve_and_pin(host: str, *, what: str = "URL") -> str:
         addrs = _resolved_addrs(host)
     except OSError as exc:
         raise PolicyError(f"{what} host {host!r} could not be resolved") from exc
+    except PolicyError as exc:
+        # Re-raise with the caller's context, so every refusal from this function
+        # names what was being resolved, not just the host.
+        raise PolicyError(f"{what} host {host!r} resolved to an unreadable address") from exc
     if not addrs:
         raise PolicyError(f"{what} host {host!r} resolved to no address")
     # Every resolved address must be public: a name that answers both a public and

--- a/src/thingctx/openapi.py
+++ b/src/thingctx/openapi.py
@@ -451,8 +451,8 @@ def _parse_spec(text: str) -> dict:
         return cast(dict, json.loads(text))
     except ValueError:
         try:
-            # optional dep, kept local so the core imports without the extra; pyyaml ships no stubs
-            import yaml  # type: ignore[import-untyped]  # noqa: PLC0415
+            # optional dep, kept local so the core imports without the extra
+            import yaml  # noqa: PLC0415
         except ImportError as exc:  # pragma: no cover - guidance path
             raise ValueError(
                 "spec is not JSON and PyYAML is not installed; "

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -460,3 +460,40 @@ async def test_kid_miss_during_cooldown_is_rejected(keypair, monkeypatch):
     with pytest.raises(AuthorizationError):
         await g.validate(attacker.mint())
     assert counter["n"] == after_first  # no further fetch during cooldown
+
+
+async def test_jwks_endpoint_answering_a_bare_list_fails_closed(keypair, monkeypatch):
+    """A 2xx says nothing about shape. A provider that answers a bare key array
+    must be refused as a 401, not cached: caching it wedges every later request
+    for the whole TTL, and the AttributeError that follows escapes past this
+    guard's fail-closed boundary as a 500."""
+    import httpx
+
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return keypair.jwks()["keys"]  # the array, not the {"keys": [...]} object
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url):
+            return FakeResp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    g = EntraGatewayGuard(tenant_id=TENANT, audience=AUDIENCE)
+    with pytest.raises(AuthorizationError):
+        await g.validate(keypair.mint())
+
+    # and the bad shape was never cached, so a later good fetch still works
+    assert g._jwks_cache is None

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -531,3 +531,35 @@ async def test_jwks_with_a_non_list_keys_member_fails_closed(keypair, monkeypatc
     with pytest.raises(AuthorizationError):
         await g.validate(keypair.mint())
     assert g._jwks_cache is None
+
+
+async def test_jwks_with_non_object_key_entries_fails_closed(keypair, monkeypatch):
+    """A list of the right type is still not a key set: a str element reaches
+    jwk.get() and raises past the fail-closed boundary."""
+    import httpx
+
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"keys": ["not-a-dict"]}
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url):
+            return FakeResp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+    g = EntraGatewayGuard(tenant_id=TENANT, audience=AUDIENCE)
+    with pytest.raises(AuthorizationError):
+        await g.validate(keypair.mint())
+    assert g._jwks_cache is None

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -595,3 +595,15 @@ async def test_jwks_with_an_empty_key_list_fails_closed(keypair, monkeypatch):
     with pytest.raises(AuthorizationError):
         await g.validate(keypair.mint())
     assert g._jwks_cache is None
+
+
+def test_a_malformed_static_jwks_is_refused_at_construction(keypair):
+    """The static jwks argument is the other door into _signing_key, and it never
+    passes through the fetch path's checks. Refuse it where it is configured, so a
+    typo fails at startup rather than on the first token."""
+    for bad in ([], {"keys": []}, {"keys": "not-a-list"}, {"keys": ["not-a-dict"]}, {}):
+        with pytest.raises(ValueError, match="static jwks"):
+            EntraGatewayGuard(tenant_id=TENANT, audience=AUDIENCE, jwks=bad)
+
+    # the good one still constructs
+    EntraGatewayGuard(tenant_id=TENANT, audience=AUDIENCE, jwks=keypair.jwks())

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -497,3 +497,37 @@ async def test_jwks_endpoint_answering_a_bare_list_fails_closed(keypair, monkeyp
 
     # and the bad shape was never cached, so a later good fetch still works
     assert g._jwks_cache is None
+
+
+async def test_jwks_with_a_non_list_keys_member_fails_closed(keypair, monkeypatch):
+    """The object check is not enough on its own: a str ``keys`` iterates into
+    characters before it fails, so the AttributeError lands in _signing_key and
+    escapes as a 500. Validate the key list too, and refuse before caching."""
+    import httpx
+
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"keys": "not-a-list"}
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url):
+            return FakeResp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    g = EntraGatewayGuard(tenant_id=TENANT, audience=AUDIENCE)
+    with pytest.raises(AuthorizationError):
+        await g.validate(keypair.mint())
+    assert g._jwks_cache is None

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -563,3 +563,35 @@ async def test_jwks_with_non_object_key_entries_fails_closed(keypair, monkeypatc
     with pytest.raises(AuthorizationError):
         await g.validate(keypair.mint())
     assert g._jwks_cache is None
+
+
+async def test_jwks_with_an_empty_key_list_fails_closed(keypair, monkeypatch):
+    """An empty key set verifies nothing. Caching it wedges auth for the whole TTL,
+    so refuse it as a 401 rather than serving a cache that can never succeed."""
+    import httpx
+
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"keys": []}
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url):
+            return FakeResp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+    g = EntraGatewayGuard(tenant_id=TENANT, audience=AUDIENCE)
+    with pytest.raises(AuthorizationError):
+        await g.validate(keypair.mint())
+    assert g._jwks_cache is None

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -515,7 +515,7 @@ def test_resolve_is_private_detects_a_private_resolution(monkeypatch):
 
 def test_resolve_is_private_treats_an_unreadable_address_as_private(monkeypatch):
     # An entry the policy cannot read must not be reported as public: it has not
-    # been shown to be safe, so the gate assumes the worse of the two.
+    # been shown to be safe, so the gate assumes the worst of the two.
     import socket as _socket
 
     def _unreadable(host, *a, **k):

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -552,3 +552,16 @@ def test_resolve_and_pin_refuses_a_resolved_name_that_is_not_an_address(monkeypa
     monkeypatch.setattr(_socket, "getaddrinfo", _name_back)
     with pytest.raises(PolicyError, match="URL host .* unreadable address"):
         resolve_and_pin("sneaky.example")
+
+
+def test_resolve_and_pin_refuses_a_malformed_getaddrinfo_tuple(monkeypatch):
+    # A resolver answering the wrong shape must still fail closed as PolicyError:
+    # an IndexError here would skip the handling every caller wrote for this gate.
+    import socket as _socket
+
+    def _short(host, *a, **k):
+        return [(_socket.AF_INET, _socket.SOCK_STREAM, 6, "")]  # no sockaddr at all
+
+    monkeypatch.setattr(_socket, "getaddrinfo", _short)
+    with pytest.raises(PolicyError, match="URL host .* unreadable address"):
+        resolve_and_pin("malformed.example")

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -537,5 +537,5 @@ def test_resolve_and_pin_refuses_an_unreadable_address_entry(monkeypatch):
         ]
 
     monkeypatch.setattr(_socket, "getaddrinfo", _mixed)
-    with pytest.raises(PolicyError, match="unreadable address entry"):
+    with pytest.raises(PolicyError, match="URL host .* unreadable address"):
         resolve_and_pin("mixed.example")

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -539,3 +539,16 @@ def test_resolve_and_pin_refuses_an_unreadable_address_entry(monkeypatch):
     monkeypatch.setattr(_socket, "getaddrinfo", _mixed)
     with pytest.raises(PolicyError, match="URL host .* unreadable address"):
         resolve_and_pin("mixed.example")
+
+
+def test_resolve_and_pin_refuses_a_resolved_name_that_is_not_an_address(monkeypatch):
+    # A str is not enough: a name that came back where an address belongs reads as
+    # "not private" and would be pinned as public.
+    import socket as _socket
+
+    def _name_back(host, *a, **k):
+        return [(_socket.AF_INET, _socket.SOCK_STREAM, 6, "", ("internal.corp", 0))]
+
+    monkeypatch.setattr(_socket, "getaddrinfo", _name_back)
+    with pytest.raises(PolicyError, match="URL host .* unreadable address"):
+        resolve_and_pin("sneaky.example")

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -20,6 +20,7 @@ from thingctx.netpolicy import (
     is_private_host,
     require_scheme,
     resolve_and_pin,
+    resolve_is_private,
 )
 from thingctx.reliability import TransportError
 from thingctx.runtime import ThingClient
@@ -497,3 +498,44 @@ def test_loopback_bind_leaves_block_private_unset(monkeypatch):
     monkeypatch.delenv("THINGCTX_BLOCK_PRIVATE", raising=False)
     _default_block_private_when_exposed("127.0.0.1")
     assert "THINGCTX_BLOCK_PRIVATE" not in os.environ
+
+
+def test_resolve_is_private_detects_a_private_resolution(monkeypatch):
+    # invariant NET-3, on the path nothing covered: a public-looking name whose
+    # A-record is private must read as private, or an SSRF check on a name is
+    # decided by its spelling.
+    import socket as _socket
+
+    def _private(host, *a, **k):
+        return [(_socket.AF_INET, _socket.SOCK_STREAM, 6, "", ("10.0.0.5", 0))]
+
+    monkeypatch.setattr(_socket, "getaddrinfo", _private)
+    assert resolve_is_private("internal.example") is True
+
+
+def test_resolve_is_private_treats_an_unreadable_address_as_private(monkeypatch):
+    # An entry the policy cannot read must not be reported as public: it has not
+    # been shown to be safe, so the gate assumes the worse of the two.
+    import socket as _socket
+
+    def _unreadable(host, *a, **k):
+        return [(0, _socket.SOCK_RAW, 0, "", (0, b"\x00\x00"))]
+
+    monkeypatch.setattr(_socket, "getaddrinfo", _unreadable)
+    assert resolve_is_private("weird.example") is True
+
+
+def test_resolve_and_pin_refuses_an_unreadable_address_entry(monkeypatch):
+    # Refuse, never skip: skipping the entry it cannot parse would let a name that
+    # also answers a private record be pinned to its public one.
+    import socket as _socket
+
+    def _mixed(host, *a, **k):
+        return [
+            (_socket.AF_INET, _socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+            (0, _socket.SOCK_RAW, 0, "", (0, b"\x00\x00")),
+        ]
+
+    monkeypatch.setattr(_socket, "getaddrinfo", _mixed)
+    with pytest.raises(PolicyError, match="unreadable address entry"):
+        resolve_and_pin("mixed.example")


### PR DESCRIPTION
Closes #57, which failed on eight type errors. Chasing them turned up two places
where a value nothing had checked was being trusted, so this is mostly not a typing
change.

**netpolicy.** `getaddrinfo` answers a family shaped sockaddr, and a family the socket
module does not model arrives as `(sa_family, raw_bytes)` with no address string. That
entry cannot be judged, so it is now refused rather than skipped. Skipping is the
tempting fix and it is the wrong one: a resolver answering a public record plus an
unreadable private one would drop the private and pin the public, inside the gate that
exists to stop exactly that. It is unreachable with the stock resolver, which answers
only AF_INET or AF_INET6 for a name. It matters because `getaddrinfo` is replaceable:
gevent, eventlet and dnspython all patch it, and so does this suite in five places.
`resolve_is_private` had no test at all, and its resolution path was the only uncovered
line in the file; netpolicy goes 99% to 100%.

**identity.** A 2xx says nothing about shape. A provider answering a bare key array was
cached as-is, so every request for the rest of the hour raised `AttributeError` inside
`_signing_key` and escaped the guard's fail-closed boundary as a 500 rather than the 401
it promises. The `cast` that silenced the type checker there was asserting an invariant
nothing enforced. There is a regression test, and it fails against the old code with the
exact `AttributeError`.

The openapi ignore deletion and the mcp annotations ride in this commit rather than
their own. mypy is pinned exactly and the hook checks the whole tree, so any split
leaves a commit that does not type check.

769 tests pass, mypy 2.3.0 reports no issues in 72 files.
