### PR TITLE
Gate the coverage of the change, not just the codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Diff coverage needs a merge base, and the default shallow clone has
+          # no common ancestor to find one against.
+          fetch-depth: 0
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
@@ -204,7 +208,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Test with branch coverage (fails below the floor)
-        run: pytest -m "not network" --cov=thingctx --cov-branch -q
+        run: pytest -m "not network" --cov=thingctx --cov-branch --cov-report=xml --cov-report=term -q
+      # The floor above protects the codebase; it does not protect the change. At
+      # 82% against a floor of 80, a pull request could add ~180 untested lines and
+      # still pass, because the rest of the tree carries the average. This asks a
+      # narrower question: are the lines THIS branch touched covered? Needs the
+      # base branch present, so it runs only where there is something to diff.
+      - name: Diff coverage (are the lines this branch touched tested?)
+        if: github.event_name == 'pull_request'
+        run: diff-cover coverage.xml --compare-branch="origin/$GITHUB_BASE_REF" --fail-under=90
 
   # The base install must stay dependency-free. Install thingctx with NO extras,
   # import the core and the authorization seam, and fail if any heavy dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ all = ["litellm>=1.0", "httpx>=0.27", "paho-mqtt>=2.0", "jsonschema>=4.0", "mcp>
 # botocore is here only as an independent oracle for the SigV4 signer: the test
 # compares our signature against botocore's canonical one. Without it installed
 # that comparison skips, so the signing code goes unchecked.
-dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.0", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13"]
+dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.0", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13", "diff-cover==10.4.1"]
 
 [project.scripts]
 # Serve a Thing (or a whole fleet of TDs) to any MCP client.


### PR DESCRIPTION
`fail_under` protects the codebase. It does not protect the change.

At 82% against a floor of 80, a pull request can add roughly **180 completely
untested statements** and still pass, because the rest of the tree carries the
average. That is not hypothetical: `netpolicy.py` reported 99% while
`resolve_is_private`'s entire resolution path had never executed once, and the floor
never noticed, since 99 is comfortably above 80.

So this adds the narrower question, asked only on a pull request: are the lines this
branch touched actually covered? `diff-cover` reads the same `coverage.xml` the
existing run now emits, compares against the base branch, and fails under 90%.

It is a pinned Python tool in the `dev` extra rather than a third-party action or an
external service, so it matches how the rest of the gate works and adds no token, no
upload, and no supply-chain surface.

Two things I checked before wiring it up. It exits 1 on newly uncovered code and 0 on
a clean diff, confirmed both ways against a deliberately untested probe function. And
it needs a real merge base, so the coverage job's checkout is no longer shallow;
without that the comparison has no common ancestor to diff against.

The existing floor stays exactly as it was. This runs beside it: the floor blocks a
regression in the whole, the diff gate blocks an untested addition.
