### PR TITLE
Fix three dead doc links, a wrong transport name, and a stale package reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ focused pull request. The contribution that matters most is this one:
 ## Add a transport (a binding)
 
 A binding teaches thingctx to speak one transport. The built-in bindings are
-Local, HTTP, MQTT, and media. CoAP, WebSocket, OPC-UA, Modbus, gRPC, serial ,
-each is one self-contained class against the `ProtocolBinding` contract that no
-one has to coordinate on:
+Local, HTTP, MQTT, exec, and media. CoAP, WebSocket, OPC-UA, Modbus, gRPC and
+serial are all wanted. Each is one self-contained class against the
+`ProtocolBinding` contract that no one has to coordinate on:
 
 ```python
 class CoapBinding:

--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -23,7 +23,7 @@ Every part is the same pattern: a `typing.Protocol` is the contract, `@implement
 checks it at import, an optional base saves boilerplate, and a conformance kit
 asserts behaviour. One example covers all four:
 [13_custom_stack.py](../examples/13_custom_stack.py). Auth is transport-neutral, so
-one provider works across every transport (see [AUTH.md](AUTH.md)). The media engine
+one provider works across every transport (see [Authentication](../README.md#authentication)). The media engine
 is a sub-contract *behind* the media binding, covered below. Discovery sources and
 media engines are constructed explicitly rather than auto-discovered, because they
 are not standalone installable transports; the entry-point path is for bindings and
@@ -69,7 +69,7 @@ protocols in `thingctx.bindings` name them:
 `invoke`, `read`, `write`, `subscribe`, and `publish` are coroutines; `handles`
 and `frames` are synchronous (`frames` returns an async iterator). Auth never
 lives in a binding: implement `with_things` and resolve credentials through the
-shared auth layer (see [AUTH.md](AUTH.md)).
+shared auth layer (see [Authentication](../README.md#authentication)).
 
 ## Registering a binding
 
@@ -129,7 +129,7 @@ itself is supplied at runtime via `credentials=` (keyed by id, slug, or scheme),
 never in the TD. Pass the `form` so a form's own security overrides the Thing's for
 that affordance (WoT form-level security), letting one Thing use a different scheme
 per plane. Custom auth *methods* are a separate, already-extensible part: register a
-provider (see [AUTH.md](AUTH.md) and `examples/13_custom_stack.py`); a binding
+provider (see [Authentication](../README.md#authentication) and `examples/13_custom_stack.py`); a binding
 consumes whatever providers resolve, transport-neutrally. A binding that needs no
 auth (like the local one) simply does not inherit `AuthMixin`.
 

--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -23,7 +23,7 @@ Every part is the same pattern: a `typing.Protocol` is the contract, `@implement
 checks it at import, an optional base saves boilerplate, and a conformance kit
 asserts behaviour. One example covers all four:
 [13_custom_stack.py](../examples/13_custom_stack.py). Auth is transport-neutral, so
-one provider works across every transport (see [Authentication](../README.md#authentication)). The media engine
+one provider works across every transport (see [Credentials](USAGE.md#credentials)). The media engine
 is a sub-contract *behind* the media binding, covered below. Discovery sources and
 media engines are constructed explicitly rather than auto-discovered, because they
 are not standalone installable transports; the entry-point path is for bindings and
@@ -69,7 +69,7 @@ protocols in `thingctx.bindings` name them:
 `invoke`, `read`, `write`, `subscribe`, and `publish` are coroutines; `handles`
 and `frames` are synchronous (`frames` returns an async iterator). Auth never
 lives in a binding: implement `with_things` and resolve credentials through the
-shared auth layer (see [Authentication](../README.md#authentication)).
+shared auth layer (see [Credentials](USAGE.md#credentials)).
 
 ## Registering a binding
 
@@ -129,7 +129,7 @@ itself is supplied at runtime via `credentials=` (keyed by id, slug, or scheme),
 never in the TD. Pass the `form` so a form's own security overrides the Thing's for
 that affordance (WoT form-level security), letting one Thing use a different scheme
 per plane. Custom auth *methods* are a separate, already-extensible part: register a
-provider (see [Authentication](../README.md#authentication) and `examples/13_custom_stack.py`); a binding
+provider (see [Credentials](USAGE.md#credentials) and `examples/13_custom_stack.py`); a binding
 consumes whatever providers resolve, transport-neutrally. A binding that needs no
 auth (like the local one) simply does not inherit `AuthMixin`.
 

--- a/docs/MAPPING.md
+++ b/docs/MAPPING.md
@@ -173,8 +173,9 @@ The scheme of a form's `href` selects its binding: `http://` and `https://` are
 bound over HTTP, `mqtt://` over MQTT, and an `href` with no scheme is handled
 locally. A single Thing may combine transports, for example reading a property over
 HTTP while subscribing to an event over MQTT within one description. Binding is
-determined per form. thingctx also bundles a subprocess transport (`exec://`) and a media
-plane; a new transport is registered without changing this mapping.
+determined per form. thingctx also ships a subprocess transport (`exec://`) and a media
+plane, the latter behind the `media` extra; a new transport is registered without changing
+this mapping.
 
 ## Limitations
 

--- a/docs/MAPPING.md
+++ b/docs/MAPPING.md
@@ -173,7 +173,7 @@ The scheme of a form's `href` selects its binding: `http://` and `https://` are
 bound over HTTP, `mqtt://` over MQTT, and an `href` with no scheme is handled
 locally. A single Thing may combine transports, for example reading a property over
 HTTP while subscribing to an event over MQTT within one description. Binding is
-determined per form. Further bindings ship as separate protocols (a shell transport,
+determined per form. Further bindings ship as separate protocols (a subprocess transport,
 a media plane); a new transport is registered without changing this mapping.
 
 ## Limitations
@@ -191,7 +191,7 @@ state.
   and property reads but not property writes or subscriptions.
 - Template variables are bound by name from the argument object; their individual
   schemas are not separately enforced at this layer.
-- The HTTP, MQTT, local, shell, and media bindings are mapped. Other bindings,
+- The HTTP, MQTT, local, exec, and media bindings are mapped. Other bindings,
   including CoAP and WebSocket, are not yet implemented.
 
 ## Status

--- a/docs/MAPPING.md
+++ b/docs/MAPPING.md
@@ -173,8 +173,8 @@ The scheme of a form's `href` selects its binding: `http://` and `https://` are
 bound over HTTP, `mqtt://` over MQTT, and an `href` with no scheme is handled
 locally. A single Thing may combine transports, for example reading a property over
 HTTP while subscribing to an event over MQTT within one description. Binding is
-determined per form. Further bindings ship as separate protocols (a subprocess transport,
-a media plane); a new transport is registered without changing this mapping.
+determined per form. thingctx also bundles a subprocess transport (`exec://`) and a media
+plane; a new transport is registered without changing this mapping.
 
 ## Limitations
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -197,11 +197,13 @@ returns an error envelope instead of running. Gating is enforced inside `invoke`
 and `write_property`, so it protects the LLM tool loop, direct callers, and the
 MCP bridge alike.
 
-On the CLI the same policy is `--approve-when declared|destructive|all|never`, or
-`THINGCTX_APPROVE_WHEN` in the environment when you configure the bridge through
-a host's JSON config. `--yes` approves unattended, which is what a script or a CI
-job needs; without a terminal and without `--yes` a gated call is denied and exits
-non-zero.
+`thingctx invoke` takes the same policy as `--approve-when
+declared|destructive|all|never`, falling back to `THINGCTX_APPROVE_WHEN` and then
+to `declared`. An unrecognized value in that variable is clamped back to
+`declared` rather than quietly degrading. The MCP bridge reads the same variable,
+which is how a host's JSON config sets the policy. `-y` / `--yes` approves
+unattended; with no terminal and no `--yes` a gated call is denied and the command
+exits with a failing status, which is the safe default for cron and CI.
 
 **Ground a TD against the live Thing.** `verify` reads each readable property and
 checks it against the declared scalar type. It only reads, so it is safe against

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -197,6 +197,12 @@ returns an error envelope instead of running. Gating is enforced inside `invoke`
 and `write_property`, so it protects the LLM tool loop, direct callers, and the
 MCP bridge alike.
 
+On the CLI the same policy is `--approve-when declared|destructive|all|never`, or
+`THINGCTX_APPROVE_WHEN` in the environment when you configure the bridge through
+a host's JSON config. `--yes` approves unattended, which is what a script or a CI
+job needs; without a terminal and without `--yes` a gated call is denied and exits
+non-zero.
+
 **Ground a TD against the live Thing.** `verify` reads each readable property and
 checks it against the declared scalar type. It only reads, so it is safe against
 production:

--- a/examples/14_authz.py
+++ b/examples/14_authz.py
@@ -14,10 +14,11 @@ Where does the identity come from? A claims dict, exactly like a token guard's
 ``validate()`` returns. In a real deployment an upstream gateway, or the guard in
 ``thingctx.identity``, validates the caller's bearer token and hands you these
 claims; core takes it as given. Core does NOT validate tokens, and that is the
-point of the split: authn (prove who the caller is) needs crypto and a network,
-authz (decide what that caller may do) needs neither and lives here. This demo
-writes the claims inline so it needs neither either. For the full chain (a real
-RS256 token validated into these claims), see ``examples/15_authn_to_authz.py``.
+point of the split: authn (prove who the caller is) verifies a signature against
+a key, authz (decide what that caller may do) is a decision over names and needs
+no crypto at all. This demo writes the claims inline, so it does no signature
+work. For the full chain (a real RS256 token validated into these claims), see
+``examples/15_authn_to_authz.py``.
 
 The pieces, smallest first:
 

--- a/examples/14_authz.py
+++ b/examples/14_authz.py
@@ -1,3 +1,5 @@
+# Copyright 2026 The thingctx Authors
+# SPDX-License-Identifier: Apache-2.0
 """Authorization on core only: read allowed, write denied, end to end.
 
 The authorization check lives INSIDE ``ThingClient``. You pass a ``pdp`` and an
@@ -9,14 +11,13 @@ extra: ``LocalPolicyGrantSource`` is the dependency-free reference grant source,
 and the device is an in-process object behind a ``LocalBinding``.
 
 Where does the identity come from? A claims dict, exactly like a token guard's
-``validate()`` returns. In a real deployment an upstream gateway (or the
-``thingctx-identity`` guard) validates the caller's bearer token and hands you
-these claims; core takes it as given. Core does NOT validate tokens, and that is
-the point of the split: authn (prove who the caller is) lives in the guard
-package, authz (decide what that caller may do) lives here in core with no
-crypto and no network. This demo writes the claims inline so it needs neither.
-For the full chain (a real RS256 token validated into these claims), see
-``thingctx-identity/examples/authn_to_authz.py``.
+``validate()`` returns. In a real deployment an upstream gateway, or the guard in
+``thingctx.identity``, validates the caller's bearer token and hands you these
+claims; core takes it as given. Core does NOT validate tokens, and that is the
+point of the split: authn (prove who the caller is) needs crypto and a network,
+authz (decide what that caller may do) needs neither and lives here. This demo
+writes the claims inline so it needs neither either. For the full chain (a real
+RS256 token validated into these claims), see ``examples/15_authn_to_authz.py``.
 
 The pieces, smallest first:
 
@@ -105,7 +106,7 @@ async def main() -> None:
     pdp = PolicyDecisionPoint(vocabulary=vocabulary, grant_source=grant_source)
 
     # 5. The identity: a claims dict, exactly what a token guard's validate()
-    #    returns. Assume an upstream gateway (or the thingctx-identity guard)
+    #    returns. Assume an upstream gateway (or the thingctx.identity guard)
     #    already validated the caller's bearer token and handed us these claims;
     #    core takes the identity as given and never checks a signature. Written
     #    inline here so the demo runs on core alone (no guard, no IdP, no token).

--- a/examples/15_authn_to_authz.py
+++ b/examples/15_authn_to_authz.py
@@ -143,7 +143,7 @@ async def main() -> None:
     issuer = Issuer()
 
     # ------------------------------------------------------------------ #
-    # AUTHN: validate a REAL token into claims. This is the guard package.
+    # AUTHN: validate a REAL token into claims. This is thingctx.identity.
     # ------------------------------------------------------------------ #
     # The guard is pointed at the issuer's PUBLIC JWKS (offline: no network,
     # like the guard's tests). It requires the 'operator' role via a Grant, so

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,8 @@ Run from the repo root with `PYTHONPATH=src`.
 | [05_oauth2.py](05_oauth2.py) | A full OAuth2 client-credentials flow, offline: local token server + protected API, driven from a TD. |
 | [13_custom_stack.py](13_custom_stack.py) | **Extending thingctx.** All four parts you can extend, in one programming model: a custom transport (`ProtocolBinding` + `AuthMixin`), auth scheme (`CredentialProvider`/`BaseAuth`), discovery source (`Registry`), and media engine (`MediaBackend`), each `@implements`-checked and run through its conformance kit. Offline. See [docs/USAGE.md](../docs/USAGE.md). |
 | [registry/](registry/) | Standalone TDs. Point `thingctx-mcp` or `from_registry` here. |
+| [interop/](interop/) | Drive TDs produced by other stacks (node-wot, Eclipse Ditto), not hand written fixtures. |
+| [oauth_connect/](oauth_connect/) | A minimal Thing with an `oauth2` / `code` scheme, so the connect flow has something to run against. |
 
 01 and 02 need no model. The pump device is [_pump.py](_pump.py) (HTTP + SSE + MQTT).
 

--- a/examples/interop/nodewot/README.md
+++ b/examples/interop/nodewot/README.md
@@ -31,7 +31,8 @@ contract.
 
 ```bash
 # 1. Start the node-wot producer (needs Node 18+)
-npm install               # deps are pinned in package.json
+cd examples/interop/nodewot
+npm install               # deps are declared in package.json
 node producer.js          # serves http://localhost:8080/counter
 
 # 2. In another shell, drive it with thingctx

--- a/examples/interop/nodewot/README.md
+++ b/examples/interop/nodewot/README.md
@@ -31,7 +31,7 @@ contract.
 
 ```bash
 # 1. Start the node-wot producer (needs Node 18+)
-npm init -y && npm install @node-wot/core @node-wot/binding-http
+npm install               # deps are pinned in package.json
 node producer.js          # serves http://localhost:8080/counter
 
 # 2. In another shell, drive it with thingctx
@@ -57,4 +57,4 @@ read  count -> 1
 node-wot defaults a Thing's `id` to a random `urn:uuid:...`, and thingctx derives
 the address prefix (slug) from that id. Either set a stable `id` in the producer
 (this demo uses `urn:dev:counter`) or derive the prefix at runtime (the binding
-does `client.list_properties()[0].split(".")[0]`), which works for any producer.
+does `client.list_properties()[0].split("__", 1)[0]`), which works for any producer.

--- a/examples/registry/camera.td.json
+++ b/examples/registry/camera.td.json
@@ -3,6 +3,8 @@
   "id": "urn:thingctx:cam:sample",
   "title": "Sample camera",
   "description": "A camera whose live stream is reached by reference. Over MCP it exposes a snapshot tool that returns one still frame as an image.",
+  "securityDefinitions": { "nosec_sc": { "scheme": "nosec" } },
+  "security": ["nosec_sc"],
   "actions": {
     "watch": {
       "description": "Capture a still frame from the camera.",

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -57,7 +57,7 @@ from thingctx.auth import (
     sigv4_sign,
 )
 
-# Binding contract: built-in transports (http, mqtt, media, local) implement it;
+# Binding contract: built-in transports (http, mqtt, media, local, exec) implement it;
 # an adopter registers their own binding to replace one or add a new protocol.
 from thingctx.bindings import (
     BUILTIN_BINDINGS,

--- a/src/thingctx/bindings/__init__.py
+++ b/src/thingctx/bindings/__init__.py
@@ -4,8 +4,8 @@
 
 A binding speaks one transport scheme and answers the runtime through the
 :class:`ProtocolBinding` contract (a ``scheme`` plus an async ``invoke``, with
-optional read / write / subscribe / media capabilities). http, mqtt, media, and
-local are the built-in bindings, shipped under :mod:`thingctx.bindings.builtin`;
+optional read / write / subscribe / media capabilities). http, mqtt, media, local,
+and exec are the built-in bindings, shipped under :mod:`thingctx.bindings.builtin`;
 each is only an implementation of the contract. Register your own binding to add
 a protocol thingctx has never heard of, or to replace a built-in, with no fork.
 

--- a/src/thingctx/bindings/builtin/__init__.py
+++ b/src/thingctx/bindings/builtin/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2026 The thingctx Authors
 # SPDX-License-Identifier: Apache-2.0
-"""The built-in bindings thingctx ships: http, mqtt, media, and local.
+"""The built-in bindings thingctx ships: http, mqtt, media, local, and exec.
 
 Each is an implementation of the :class:`~thingctx.bindings.base.ProtocolBinding`
 contract, privileged only by being bundled. An adopter can replace any of

--- a/src/thingctx/bindings/registry.py
+++ b/src/thingctx/bindings/registry.py
@@ -82,7 +82,9 @@ class BindingRegistry:
     ) -> BindingRegistry:
         """The default registry of built-in bindings. http and local match the
         default client (the documented quickstart); mqtt and media are opt in
-        because they pull optional dependencies."""
+        because they pull optional dependencies. exec has no switch here: it
+        refuses every command until it is given an allowlist, so it is built
+        directly and registered rather than enabled by a flag."""
         reg = cls()
         for name, want in (
             ("http", http),

--- a/src/thingctx/bindings/registry.py
+++ b/src/thingctx/bindings/registry.py
@@ -3,7 +3,7 @@
 """The binding registry: how the built-in bindings are assembled and how an
 adopter replaces one or adds a new protocol.
 
-http, mqtt, media, and local are the built-in bindings; each is only an
+http, mqtt, media, local, and exec are the built-in bindings; each is only an
 implementation of the :class:`~thingctx.bindings.base.ProtocolBinding` contract.
 
     reg = BindingRegistry.default()   # http + local, the safe default

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -89,3 +89,26 @@ def test_time_td_is_schema_valid():
 
     td = json.loads((EXAMPLES / "registry" / "time.td.json").read_text())
     assert validate_td(td) == []
+
+
+def test_every_example_td_is_schema_valid():
+    """Every TD we ship validates, not just the quickstart one. The README serves
+    the whole registry folder, so an invalid TD in it breaks the first thing a
+    reader runs."""
+    pytest.importorskip("jsonschema")
+    from thingctx import validate_td
+
+    found = []
+    for path in sorted(EXAMPLES.rglob("*.json")):
+        try:
+            doc = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            continue
+        # A TD is identified by its @context, which is what tells the registry
+        # loader this file is a Thing Description and not adjacent config.
+        if not isinstance(doc, dict) or "wot/td" not in str(doc.get("@context", "")):
+            continue
+        found.append(path)
+        assert validate_td(doc) == [], f"{path.relative_to(REPO)} is not a valid TD"
+
+    assert found, "no example TDs discovered; the glob or the layout changed"

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -100,10 +100,12 @@ def test_every_example_td_is_schema_valid():
 
     found = []
     for path in sorted(EXAMPLES.rglob("*.json")):
+        # A shipped file that will not parse is a failure whatever it is; skipping
+        # it here would hide the very breakage this test exists to catch.
         try:
             doc = json.loads(path.read_text())
-        except json.JSONDecodeError:
-            continue
+        except json.JSONDecodeError as exc:
+            raise AssertionError(f"{path.relative_to(REPO)} is not valid JSON: {exc}") from exc
         # A TD is identified by its @context, which is what tells the registry
         # loader this file is a Thing Description and not adjacent config.
         if not isinstance(doc, dict) or "wot/td" not in str(doc.get("@context", "")):

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -88,4 +88,4 @@ def test_time_td_is_schema_valid():
     from thingctx import validate_td
 
     td = json.loads((EXAMPLES / "registry" / "time.td.json").read_text())
-    validate_td(td)
+    assert validate_td(td) == []


### PR DESCRIPTION
Corrections to things the docs asserted that were not true, plus the two bugs that turned up while checking them.

The bugs: `examples/registry/camera.td.json` declared no security, so the folder the README quickstart tells you to serve held an invalid TD 1.1 document. And `test_time_td_is_schema_valid` called `validate_td` without asserting on the result, which that function returns rather than raises, so it passed on an invalid TD. Every shipped TD is now checked.

The corrections: three dead `AUTH.md` links now point at the credentials section that exists; `CONTRIBUTING`, `MAPPING` and four docstrings listed four built in bindings when there are five; the authz example described a `thingctx-identity` package that never shipped; and the node-wot walkthrough ran `npm init` over its own committed `package.json`.

`docs/USAGE.md` also gains a paragraph on the CLI trust flags. They were documented in the README and SKILL.md but not in the trust section, which is where a reader looking for them would go.
