### PR TITLE
lint: flag a tool namespace a model cannot group by

### DIFF
--- a/src/thingctx/lint.py
+++ b/src/thingctx/lint.py
@@ -24,7 +24,7 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from thingctx.thing import _tool_name
+from thingctx.thing import thing_slug
 
 # The tool-name charset the OpenAI/Anthropic function-calling APIs accept. A name
 # outside this set is silently rejected by a provider at call time, so flag it
@@ -47,11 +47,12 @@ _SINGLE_TOKEN = re.compile(r"^\S+$")
 _CREDENTIAL_HEADERS = {"authorization", "cookie", "proxy-authorization"}
 _CREDENTIAL_HINT = re.compile(r"(api[-_]?key|token|secret|password|bearer)", re.IGNORECASE)
 
-# Namespace slugs that are too thin to help a model group tools.
-# Single-letter slugs are always unusable. ``t1``, ``x999``, ``a1`` are
-# clearly placeholder- or example-shaped. Deliberately conservative:
-# a short but meaningful abbreviation like ``db`` is not flagged.
-_THIN_NAMESPACE = re.compile(r"^(?:[a-z]\d?|[tx]\d+)$", re.I)
+# Slugs that name nothing: scaffolding words a generator leaves behind, and bare
+# single letters. Shape alone cannot settle the rest, since ``s3`` and ``k8`` read
+# like placeholders and are not, so the Thing's own title arbitrates below.
+_THIN_NAMESPACE = re.compile(
+    r"^(?:thing|test|foo|bar|baz|sample|example|demo|tbd|todo|[a-z])\d*$", re.IGNORECASE
+)
 
 _MIN_DESCRIPTION = 8  # a description under this many characters carries no meaning
 
@@ -108,12 +109,6 @@ def lint_td(td: dict[str, Any]) -> list[LintFinding]:
     return out
 
 
-def _slug_from_id(thing_id: str) -> str:
-    """Extract the namespace slug from a Thing id (delegates to
-    ``_tool_name`` in thing.py for the canonical slug logic)."""
-    return _tool_name(thing_id, "_").rsplit(".", 1)[0]
-
-
 def _lint_id(td: dict[str, Any], out: list[LintFinding]) -> None:
     tid = td.get("id") or td.get("@id")
     if isinstance(tid, str) and tid.startswith(("http://", "https://")):
@@ -130,20 +125,42 @@ def _lint_id(td: dict[str, Any], out: list[LintFinding]) -> None:
         )
 
 
+def _abbreviates(slug: str, title: str) -> bool:
+    # An abbreviation starts where its subject starts, and its letters follow in
+    # order. Digits are not required to appear: ``k8s`` counts the letters it
+    # elides from "kubernetes" rather than quoting them.
+    if not slug or not title or slug[0] != title[0]:
+        return False
+    rest = iter(title)
+    return all(c in rest for c in slug if c.isalpha())
+
+
 def _lint_thin_namespace(td: dict[str, Any], out: list[LintFinding]) -> None:
     tid = td.get("id") or td.get("@id")
-    if not isinstance(tid, str):
+    title = td.get("title") if isinstance(td.get("title"), str) else ""
+    from_id = isinstance(tid, str) and bool(tid.strip())
+    # An id-less Thing still projects tools, off its title.
+    source = tid if from_id else title
+    if not isinstance(source, str) or not source.strip():
         return
-    slug = _slug_from_id(tid)
-    if len(slug) == 1 or _THIN_NAMESPACE.match(slug):
+    slug = thing_slug(source)
+    # A slug the title abbreviates is grounded in what the Thing is, however
+    # short: ``s3`` for "S3 Bucket" and ``db`` for "Database" name their subject,
+    # ``t1`` for "Water Pump" names nothing. The title has to say more than the
+    # slug to ground it, and an id-less Thing skips the check because its slug
+    # came from that title.
+    if from_id and title:
+        grounded = re.sub(r"[^a-z0-9]", "", title.lower())
+        if len(grounded) > len(slug) and _abbreviates(slug.lower(), grounded):
+            return
+    if len(slug) <= 2 or _THIN_NAMESPACE.match(slug):
         out.append(
             LintFinding(
                 "notice",
                 "id",
                 "thin_namespace",
-                f"Thing id {tid!r} projects to a thin namespace {slug!r}; a model "
-                "cannot group tools by a namespace this short. Prefer a meaningful "
-                "device or service id.",
+                f"tool namespace {slug!r} gives a model no category to group this "
+                "Thing's tools by. Prefer a meaningful device or service id.",
             )
         )
 

--- a/src/thingctx/lint.py
+++ b/src/thingctx/lint.py
@@ -136,24 +136,28 @@ def _abbreviates(slug: str, title: str) -> bool:
 
 
 def _lint_thin_namespace(td: dict[str, Any], out: list[LintFinding]) -> None:
-    tid = td.get("id") or td.get("@id")
-    title = td.get("title") if isinstance(td.get("title"), str) else ""
-    from_id = isinstance(tid, str) and bool(tid.strip())
+    ids = (td.get("id"), td.get("@id"))
+    tid: str = next((v for v in ids if isinstance(v, str) and v.strip()), "")
+    raw_title = td.get("title")
+    title: str = raw_title if isinstance(raw_title, str) else ""
     # An id-less Thing still projects tools, off its title.
-    source = tid if from_id else title
-    if not isinstance(source, str) or not source.strip():
+    source = tid or title
+    if not source.strip():
         return
     slug = thing_slug(source)
+    # Separators carry no meaning here: ``thing-1`` and ``x_999`` are the same
+    # placeholders as ``thing1`` and ``x999``.
+    bare = re.sub(r"[-_]", "", slug).lower()
     # A slug the title abbreviates is grounded in what the Thing is, however
     # short: ``s3`` for "S3 Bucket" and ``db`` for "Database" name their subject,
     # ``t1`` for "Water Pump" names nothing. The title has to say more than the
-    # slug to ground it, and an id-less Thing skips the check because its slug
-    # came from that title.
-    if from_id and title:
+    # slug to ground it, and a slug taken from the title is never compared
+    # against it, since the two would not be independent.
+    if tid and title:
         grounded = re.sub(r"[^a-z0-9]", "", title.lower())
-        if len(grounded) > len(slug) and _abbreviates(slug.lower(), grounded):
+        if len(grounded) > len(bare) and _abbreviates(bare, grounded):
             return
-    if len(slug) <= 2 or _THIN_NAMESPACE.match(slug):
+    if len(bare) <= 2 or _THIN_NAMESPACE.match(bare):
         out.append(
             LintFinding(
                 "notice",

--- a/src/thingctx/lint.py
+++ b/src/thingctx/lint.py
@@ -24,6 +24,8 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from thingctx.thing import _tool_name
+
 # The tool-name charset the OpenAI/Anthropic function-calling APIs accept.
 # ``_tool_name`` in thing.py keeps ``. _ -`` in the slug; a name outside this
 # set is silently rejected by a provider at call time, so flag it here.
@@ -40,6 +42,12 @@ _SINGLE_TOKEN = re.compile(r"^\S+$")
 # a credential in ``htv:headers`` is the one thing the security posture forbids.
 _CREDENTIAL_HEADERS = {"authorization", "cookie", "proxy-authorization"}
 _CREDENTIAL_HINT = re.compile(r"(api[-_]?key|token|secret|password|bearer)", re.I)
+
+# Namespace slugs that are too thin to help a model group tools.
+# Single-letter slugs are always unusable. ``t1``, ``x999``, ``a1`` are
+# clearly placeholder- or example-shaped. Deliberately conservative:
+# a short but meaningful abbreviation like ``db`` is not flagged.
+_THIN_NAMESPACE = re.compile(r"^(?:[a-z]\d?|[tx]\d+)$", re.I)
 
 _MIN_DESCRIPTION = 8  # a description under this many characters carries no meaning
 
@@ -97,13 +105,9 @@ def lint_td(td: dict[str, Any]) -> list[LintFinding]:
 
 
 def _slug_from_id(thing_id: str) -> str:
-    """Extract the namespace slug from a Thing id (same logic as
-    ``_tool_name`` in thing.py)."""
-    parts = [p for p in str(thing_id).split(":") if p]
-    if len(parts) >= 2 and parts[-1].lower().lstrip("v").isdigit():
-        parts = parts[:-1]
-    slug = parts[-1] if parts else str(thing_id)
-    return "".join(c if (c.isalnum() or c in "._-") else "-" for c in slug)
+    """Extract the namespace slug from a Thing id (delegates to
+    ``_tool_name`` in thing.py for the canonical slug logic)."""
+    return _tool_name(thing_id, "_").rsplit(".", 1)[0]
 
 
 def _lint_id(td: dict[str, Any], out: list[LintFinding]) -> None:
@@ -127,14 +131,15 @@ def _lint_thin_namespace(td: dict[str, Any], out: list[LintFinding]) -> None:
     if not isinstance(tid, str):
         return
     slug = _slug_from_id(tid)
-    if len(slug) <= 2:
+    if len(slug) == 1 or _THIN_NAMESPACE.match(slug):
         out.append(
             LintFinding(
                 "notice",
                 "id",
                 "thin_namespace",
-                f"Thing id {tid!r} projects to a {len(slug)}-character namespace "
-                f"({slug!r}); a model cannot group tools by a namespace this short.",
+                f"Thing id {tid!r} projects to a thin namespace {slug!r}; a model "
+                "cannot group tools by a namespace this short. Prefer a meaningful "
+                "device or service id.",
             )
         )
 

--- a/src/thingctx/lint.py
+++ b/src/thingctx/lint.py
@@ -70,6 +70,7 @@ def lint_td(td: dict[str, Any]) -> list[LintFinding]:
     out: list[LintFinding] = []
 
     _lint_id(td, out)
+    _lint_thin_namespace(td, out)
     _lint_thing_type(td, out)
 
     for kind in ("actions", "properties", "events"):
@@ -95,6 +96,16 @@ def lint_td(td: dict[str, Any]) -> list[LintFinding]:
     return out
 
 
+def _slug_from_id(thing_id: str) -> str:
+    """Extract the namespace slug from a Thing id (same logic as
+    ``_tool_name`` in thing.py)."""
+    parts = [p for p in str(thing_id).split(":") if p]
+    if len(parts) >= 2 and parts[-1].lower().lstrip("v").isdigit():
+        parts = parts[:-1]
+    slug = parts[-1] if parts else str(thing_id)
+    return "".join(c if (c.isalnum() or c in "._-") else "-" for c in slug)
+
+
 def _lint_id(td: dict[str, Any], out: list[LintFinding]) -> None:
     tid = td.get("id") or td.get("@id")
     if isinstance(tid, str) and tid.startswith(("http://", "https://")):
@@ -107,6 +118,23 @@ def _lint_id(td: dict[str, Any], out: list[LintFinding]) -> None:
                 "url_shaped_id",
                 "id is a URL; the tool-name prefix is derived from its last path "
                 "segment and may collide. Prefer a urn: id.",
+            )
+        )
+
+
+def _lint_thin_namespace(td: dict[str, Any], out: list[LintFinding]) -> None:
+    tid = td.get("id") or td.get("@id")
+    if not isinstance(tid, str):
+        return
+    slug = _slug_from_id(tid)
+    if len(slug) <= 2:
+        out.append(
+            LintFinding(
+                "notice",
+                "id",
+                "thin_namespace",
+                f"Thing id {tid!r} projects to a {len(slug)}-character namespace "
+                f"({slug!r}); a model cannot group tools by a namespace this short.",
             )
         )
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -184,6 +184,23 @@ def test_thin_namespace_flagged_for_two_char_id():
     assert "thin_namespace" in _rules(td)
 
 
+def test_thin_namespace_does_not_flag_meaningful_short_name():
+    td = {
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "@type": "saref:Pump",
+        "id": "urn:demo:db:v1",
+        "title": "Database",
+        "actions": {
+            "query": {
+                "description": "Run a query.",
+                "safe": True,
+                "forms": [{"href": "https://d/query"}],
+            }
+        },
+    }
+    assert "thin_namespace" not in _rules(td)
+
+
 def test_findings_are_advice_never_an_exception():
     # a sparse but well-formed dict lints without raising
     assert isinstance(lint_td({"id": "urn:myapp", "title": "MyApp"}), list)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -5,6 +5,8 @@ rejects a clean one. All offline: TDs are built inline."""
 
 from __future__ import annotations
 
+import pytest
+
 from thingctx.lint import lint_td
 
 
@@ -204,3 +206,72 @@ def test_thin_namespace_does_not_flag_meaningful_short_name():
 def test_findings_are_advice_never_an_exception():
     # a sparse but well-formed dict lints without raising
     assert isinstance(lint_td({"id": "urn:myapp", "title": "MyApp"}), list)
+
+
+def _thin_td(thing_id: str | None, title: str) -> dict:
+    td: dict = {
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "@type": "saref:Pump",
+        "title": title,
+        "actions": {
+            "go": {"description": "Do the thing.", "safe": True, "forms": [{"href": "https://d"}]}
+        },
+    }
+    if thing_id is not None:
+        td["id"] = thing_id
+    return td
+
+
+@pytest.mark.parametrize(
+    "thing_id,title",
+    [
+        ("urn:demo:s3", "S3 Bucket"),
+        ("urn:demo:k8", "Kubernetes"),
+        ("urn:demo:k8s", "Kubernetes"),
+        ("urn:demo:i18n", "Internationalization"),
+        ("urn:demo:py", "Python"),
+        ("urn:demo:gh", "GitHub"),
+        ("urn:demo:ec2", "EC2 Instance"),
+        ("urn:demo:pump", "Water Pump"),
+        ("urn:thingctx:cam:sample", "Sample camera"),
+    ],
+)
+def test_namespace_the_title_abbreviates_is_not_thin(thing_id, title):
+    assert "thin_namespace" not in _rules(_thin_td(thing_id, title))
+
+
+@pytest.mark.parametrize(
+    "thing_id",
+    [
+        "urn:demo:x",
+        "urn:demo:t1",
+        "urn:demo:n1",
+        "urn:demo:zz",
+        "urn:demo:x999",
+        "urn:demo:thing1",
+        "urn:demo:test",
+        "urn:demo:foo",
+        "urn:demo:xz",
+    ],
+)
+def test_namespace_the_title_does_not_explain_is_thin(thing_id):
+    assert "thin_namespace" in _rules(_thin_td(thing_id, "Water Pump"))
+
+
+def test_thin_namespace_falls_back_to_title_when_there_is_no_id():
+    assert "thin_namespace" in _rules(_thin_td(None, "X"))
+    assert "thin_namespace" not in _rules(_thin_td(None, "Water Pump"))
+
+
+def test_thin_namespace_is_reported_once_per_thing():
+    td = _thin_td("urn:demo:x", "Water Pump")
+    td["properties"] = {"p": {"description": "A value.", "forms": [{"href": "https://d"}]}}
+    td["events"] = {"e": {"description": "A signal.", "forms": [{"href": "https://d"}]}}
+    assert [f.rule for f in lint_td(td)].count("thin_namespace") == 1
+
+
+def test_thin_namespace_reads_the_projected_namespace_not_the_raw_id():
+    # Pins the rule to thing_slug, so a change to the tool-name separator cannot
+    # silently stop it firing.
+    assert "thin_namespace" in _rules(_thin_td("urn:demo:x", "Water Pump"))
+    assert "thin_namespace" not in _rules(_thin_td("urn:demo:pump:v1", "Water Pump"))

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -45,8 +45,8 @@ def test_a_clean_td_produces_no_findings():
 
 def test_thin_description_and_generated_name():
     td = {
-        "id": "urn:demo:x",
-        "title": "X",
+        "id": "urn:demo:myapp",
+        "title": "MyApp",
         "actions": {
             # no description, no title -> thin; name looks importer-generated
             "get_users_id": {"forms": [{"href": "https://d/u"}]},
@@ -59,8 +59,8 @@ def test_thin_description_and_generated_name():
 
 def test_invalid_tool_name_is_an_error():
     td = {
-        "id": "urn:demo:x",
-        "title": "X",
+        "id": "urn:demo:myapp",
+        "title": "MyApp",
         # a slash-shaped name (GitHub-style) is outside the accepted charset
         "actions": {"repos/get": {"description": "Get a repo.", "forms": [{"href": "https://d"}]}},
     }
@@ -70,8 +70,8 @@ def test_invalid_tool_name_is_an_error():
 
 def test_empty_parameters_flagged():
     td = {
-        "id": "urn:demo:x",
-        "title": "X",
+        "id": "urn:demo:myapp",
+        "title": "MyApp",
         "actions": {
             "do_it": {
                 "description": "Do the thing now.",
@@ -86,8 +86,8 @@ def test_empty_parameters_flagged():
 
 def test_credential_shaped_header_is_an_error():
     td = {
-        "id": "urn:demo:x",
-        "title": "X",
+        "id": "urn:demo:myapp",
+        "title": "MyApp",
         "actions": {
             "call": {
                 "description": "Call the endpoint.",
@@ -128,8 +128,8 @@ def test_url_shaped_id_and_missing_types():
 
 def test_unmarked_risk_notice():
     td = {
-        "id": "urn:demo:x",
-        "title": "X",
+        "id": "urn:demo:myapp",
+        "title": "MyApp",
         "actions": {
             # no safe, no idempotent, no tc: marking
             "reboot": {"description": "Reboot the device.", "forms": [{"href": "https://d"}]}
@@ -138,6 +138,52 @@ def test_unmarked_risk_notice():
     assert "unmarked_risk" in _rules(td)
 
 
+def test_thin_namespace_flagged_for_short_id():
+    td = {
+        "id": "x",
+        "title": "X",
+        "actions": {
+            "do_it": {
+                "description": "Do the thing.",
+                "safe": True,
+                "forms": [{"href": "https://d"}],
+            }
+        },
+    }
+    rules = _rules(td)
+    assert "thin_namespace" in rules
+
+
+def test_thin_namespace_clean_for_normal_id():
+    td = {
+        "id": "urn:demo:pump:v1",
+        "title": "Pump",
+        "actions": {
+            "set_speed": {
+                "description": "Set the speed.",
+                "safe": True,
+                "forms": [{"href": "https://d"}],
+            }
+        },
+    }
+    assert "thin_namespace" not in _rules(td)
+
+
+def test_thin_namespace_flagged_for_two_char_id():
+    td = {
+        "id": "urn:t1",
+        "title": "T1",
+        "actions": {
+            "read": {
+                "description": "Read value.",
+                "safe": True,
+                "forms": [{"href": "https://d"}],
+            }
+        },
+    }
+    assert "thin_namespace" in _rules(td)
+
+
 def test_findings_are_advice_never_an_exception():
     # a sparse but well-formed dict lints without raising
-    assert isinstance(lint_td({"id": "urn:x", "title": "X"}), list)
+    assert isinstance(lint_td({"id": "urn:myapp", "title": "MyApp"}), list)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -252,6 +252,9 @@ def test_namespace_the_title_abbreviates_is_not_thin(thing_id, title):
         "urn:demo:test",
         "urn:demo:foo",
         "urn:demo:xz",
+        "urn:demo:thing-1",
+        "urn:demo:x_999",
+        "urn:demo:t_1",
     ],
 )
 def test_namespace_the_title_does_not_explain_is_thin(thing_id):
@@ -275,3 +278,10 @@ def test_thin_namespace_reads_the_projected_namespace_not_the_raw_id():
     # silently stop it firing.
     assert "thin_namespace" in _rules(_thin_td("urn:demo:x", "Water Pump"))
     assert "thin_namespace" not in _rules(_thin_td("urn:demo:pump:v1", "Water Pump"))
+
+
+def test_thin_namespace_reads_at_id_when_id_is_blank():
+    td = _thin_td(None, "Water Pump")
+    td["id"] = "   "
+    td["@id"] = "urn:demo:x"
+    assert "thin_namespace" in _rules(td)


### PR DESCRIPTION
Lands the `thin_namespace` lint rule from #36, and fixes it against the current tool name separator.

Closes #35.
