### PR TITLE
test: cover time handler error paths and ISO parsing

### DIFF
--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,59 @@
+# Copyright 2026 The thingctx Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the bundled in-process time handler."""
+
+from __future__ import annotations
+
+import pytest
+
+from thingctx.contrib.time import TimeHandler
+
+
+def test_get_current_time_rejects_unknown_timezone():
+    handler = TimeHandler()
+
+    with pytest.raises(ValueError, match="unknown IANA timezone"):
+        handler.getCurrentTime("Not/A_Real_Zone")
+
+
+def test_convert_time_rejects_unrecognized_time():
+    handler = TimeHandler()
+
+    with pytest.raises(ValueError, match="unrecognized time"):
+        handler.convertTime(
+            "not-a-time",
+            source_timezone="UTC",
+            target_timezone="Asia/Tokyo",
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_source", "expected_target"),
+    [
+        (
+            "2026-01-15T09:00:00",
+            "2026-01-15T09:00:00+00:00",
+            "2026-01-15T18:00:00+09:00",
+        ),
+        (
+            "2026-01-15T09:00:00+02:00",
+            "2026-01-15T09:00:00+02:00",
+            "2026-01-15T16:00:00+09:00",
+        ),
+    ],
+)
+def test_convert_time_accepts_iso_8601(
+    value,
+    expected_source,
+    expected_target,
+):
+    handler = TimeHandler()
+
+    result = handler.convertTime(
+        value,
+        source_timezone="UTC",
+        target_timezone="Asia/Tokyo",
+    )
+
+    assert result["source"]["datetime"] == expected_source
+    assert result["target"]["datetime"] == expected_target


### PR DESCRIPTION
## What this does

Adds focused tests for the time handler's error paths and ISO 8601 parsing behavior.

The tests cover:

- an unknown timezone
- an unrecognized time value
- ISO 8601 input without an embedded offset
- ISO 8601 input with an embedded offset

This tests the existing behavior without changing production code.

Closes #90

## How you checked it

- `python3 -m ruff check tests/test_time.py`
- `python3 -m pytest tests/test_time.py -v`
- `python3 -m pytest -m "not network" --cov=thingctx --cov-branch -q`

Full offline suite:

- 718 passed
- 62 skipped
- 4 deselected
- 1 xfailed
- Total coverage: 81.43%