### PR TITLE
Add --version flag to thingctx CLI

### DIFF
--- a/src/thingctx/cli.py
+++ b/src/thingctx/cli.py
@@ -31,7 +31,6 @@ registered Thing through these commands; ``skill install`` copies it under
 """
 
 from __future__ import annotations
-from thingctx import __version__
 
 import argparse
 import asyncio
@@ -44,6 +43,8 @@ from collections.abc import Callable
 from importlib.resources import files
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+
+from thingctx import __version__
 
 if TYPE_CHECKING:
     from thingctx.runtime import ThingClient

--- a/src/thingctx/cli.py
+++ b/src/thingctx/cli.py
@@ -31,6 +31,7 @@ registered Thing through these commands; ``skill install`` copies it under
 """
 
 from __future__ import annotations
+from thingctx import __version__
 
 import argparse
 import asyncio
@@ -436,6 +437,11 @@ def _cmd_skill_install(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(prog="thingctx", description="WoT Thing Description tooling.")
+    ap.add_argument(
+    "--version",
+    action="version",
+    version=f"thingctx {__version__}",
+)
     sub = ap.add_subparsers(dest="command", required=True)
 
     imp = sub.add_parser("import", help="import a non-WoT description into a TD")

--- a/src/thingctx/cli.py
+++ b/src/thingctx/cli.py
@@ -439,10 +439,10 @@ def _cmd_skill_install(args: argparse.Namespace) -> int:
 def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(prog="thingctx", description="WoT Thing Description tooling.")
     ap.add_argument(
-    "--version",
-    action="version",
-    version=f"thingctx {__version__}",
-)
+        "--version",
+        action="version",
+        version=f"thingctx {__version__}",
+    )
     sub = ap.add_subparsers(dest="command", required=True)
 
     imp = sub.add_parser("import", help="import a non-WoT description into a TD")


### PR DESCRIPTION
Closes #76

Adds a --version flag to the CLI using argparse's built-in action="version", so thingctx --version prints the installed version instead of erroring as an unrecognized argument.

Ran `thingctx --version` after an editable install and confirmed it prints the correct version and exits cleanly:

​```
$ thingctx --version
thingctx 0.1.3
​```