### PR TITLE
release: 0.2.0

### DIFF
--- a/examples/interop/ditto/README.md
+++ b/examples/interop/ditto/README.md
@@ -62,7 +62,7 @@ server-side (twin state), so it works without a physical device attached. The
 
 # 2. Drive the twin with thingctx
 python3 -m venv .venv && . .venv/bin/activate
-pip install "thingctx[http]==0.1.3"
+pip install "thingctx[http]"
 python drive_ditto_td.py
 
 # 3. Tear down

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thingctx"
-version = "0.1.3"
+version = "0.2.0"
 description = "Drive any agent against any W3C WoT Thing, over any transport. No per-integration server."
 readme = "README-pypi.md"
 requires-python = ">=3.10"

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -132,7 +132,7 @@ from thingctx.trust import (
 )
 from thingctx.validate import TDValidationError, validate_td
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"
 
 __all__ = [
     "BUILTIN_BINDINGS",


### PR DESCRIPTION
Bumps the version to 0.2.0.

`pyproject.toml` and `__init__.py` both still said 0.1.3 while every manifest said 0.2.0, so tagging would have published a 0.1.3 wheel under a 0.2.0 release. The Ditto walkthrough pinned 0.1.3 as well and now installs the current release.

Verified against the built artifacts rather than the working tree: `twine check` passes on the wheel and the sdist, the wheel metadata carries the rewritten PyPI page, and in a clean virtualenv where `thingctx==0.2.0` is the only installed package the README quickstart runs and prints a real timestamp.
