### PR TITLE
fix(release): keep repo dependent tests out of the installed package smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,21 @@ jobs:
           # ci.yml runs those against the source tree. Selected by what a test
           # actually does, so a new one does not silently break the release.
           cp tests/*.py "$RUNNER_TEMP/t/"
-          grep -lE "parents\[[0-9]\]|parent\.parent|\"examples\"|'examples'|\"scripts\"|from _pump" \
-            "$RUNNER_TEMP/t"/*.py | xargs -r rm -f
-          echo "kept $(ls "$RUNNER_TEMP/t"/test_*.py | wc -l) test files"
+          # No pipeline: grep -l exits 1 when nothing matches, which would fail
+          # this step under pipefail once every repo dependent test is gone.
+          removed=0
+          for f in "$RUNNER_TEMP/t"/test_*.py; do
+            if grep -qE "parents\[[0-9]\]|parent\.parent|[\"']examples[\"']|[\"']scripts[\"']|from _pump" "$f"; then
+              rm -f "$f"
+              removed=$((removed + 1))
+            fi
+          done
+          kept=$(find "$RUNNER_TEMP/t" -name 'test_*.py' -type f | wc -l)
+          echo "kept $kept test files, skipped $removed that read repo files"
+          if [ "$kept" -lt 50 ]; then
+            echo "::error::only $kept test files survived; the filter is too broad"
+            exit 1
+          fi
           printf '[pytest]\nmarkers = network: hits the network; deselect with -m "not network"\nasyncio_mode = auto\n' > "$RUNNER_TEMP/t/pytest.ini"
           cd "$RUNNER_TEMP/t"
           pytest -m "not network" -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,15 @@ jobs:
       - name: Test installed package (offline, isolated from source)
         run: |
           mkdir -p "$RUNNER_TEMP/t"
+          # This job proves the WHEEL works, so it runs from a bare directory with
+          # no checkout on sys.path. Any test that reads repo files (examples/,
+          # scripts/) cannot pass here and is not about the installed package;
+          # ci.yml runs those against the source tree. Selected by what a test
+          # actually does, so a new one does not silently break the release.
           cp tests/*.py "$RUNNER_TEMP/t/"
+          grep -lE "parents\[[0-9]\]|parent\.parent|\"examples\"|'examples'|\"scripts\"|from _pump" \
+            "$RUNNER_TEMP/t"/*.py | xargs -r rm -f
+          echo "kept $(ls "$RUNNER_TEMP/t"/test_*.py | wc -l) test files"
           printf '[pytest]\nmarkers = network: hits the network; deselect with -m "not network"\nasyncio_mode = auto\n' > "$RUNNER_TEMP/t/pytest.ini"
           cd "$RUNNER_TEMP/t"
           pytest -m "not network" -q


### PR DESCRIPTION
Unblocks the v0.2.0 release.

The smoke job copies the whole test suite into a bare directory to prove the wheel works with no checkout on `sys.path`. Four of those tests read files a wheel does not ship, under `examples/` and `scripts/`, so they failed collection on all three Python versions and the release stopped before PyPI. The package itself was fine: TestPyPI published and installed correctly.

They are now excluded by what a test actually does rather than by a list of names, so adding another test that reads a repo file cannot silently break a release later.

Verified by reproducing the job locally against thingctx 0.2.0 installed from TestPyPI, not against the working tree: 68 test files kept, 772 pass.
