### PR TITLE
feat(release): build the Claude Desktop bundle before the publish gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,38 @@ jobs:
           cd "$RUNNER_TEMP/t"
           pytest -m "not network" -q
 
+  # Built BEFORE the PyPI gate so the paused run already carries an installable
+  # bundle. Download it from the run's artifacts, install it in Claude Desktop,
+  # and dogfood the approve flow before approving the publish. The bundle is a
+  # launcher: uv resolves thingctx from PyPI at first launch, so it can only be
+  # driven end to end once the publish is approved.
+  bundle:
+    name: build the Claude Desktop bundle
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - name: Bundle version must match the release tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          MANIFEST=$(python3 -c "import json;print(json.load(open('packaging/mcpb/manifest.json'))['version'])")
+          if [ "$TAG" != "$MANIFEST" ]; then
+            echo "::error::manifest.json says $MANIFEST, tag says $TAG"
+            exit 1
+          fi
+          echo "bundle version $MANIFEST matches the tag"
+      - run: bash packaging/scripts/build-mcpb.sh
+      - uses: actions/upload-artifact@v7
+        with:
+          name: mcpb
+          path: packaging/dist/thingctx.mcpb
+
   pypi:
     name: publish to PyPI
-    needs: smoke
+    needs: [smoke, bundle]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -130,6 +159,10 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: dist
+          path: dist/
+      - uses: actions/download-artifact@v8
+        with:
+          name: mcpb
           path: dist/
       - uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,9 @@ jobs:
       - name: Bundle version must match the release tag
         run: |
           TAG="${GITHUB_REF_NAME#v}"
-          MANIFEST=$(python3 -c "import json;print(json.load(open('packaging/mcpb/manifest.json'))['version'])")
+          # node, not python3: this job already sets node up for the packer, so
+          # reading the manifest with it avoids depending on the runner's python.
+          MANIFEST=$(node -p "require('./packaging/mcpb/manifest.json').version")
           if [ "$TAG" != "$MANIFEST" ]; then
             echo "::error::manifest.json says $MANIFEST, tag says $TAG"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - run: pip install build
       - run: python -m build
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
@@ -33,7 +33,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
@@ -55,7 +55,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install from TestPyPI (retry until index propagates)
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
       - name: Bundle version must match the release tag
@@ -129,7 +129,7 @@ jobs:
           fi
           echo "bundle version $MANIFEST matches the tag"
       - run: bash packaging/scripts/build-mcpb.sh
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mcpb
           path: packaging/dist/thingctx.mcpb
@@ -142,7 +142,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
@@ -158,15 +158,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: mcpb
           path: dist/
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@c12583777ecdfd3be55c69cf75464299dc01057e # v3
         with:
           generate_release_notes: true
           files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -54,7 +54,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
@@ -113,7 +113,7 @@ jobs:
     needs: smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@v5
         with:
           node-version: "22"

--- a/packaging/scripts/build-mcpb.sh
+++ b/packaging/scripts/build-mcpb.sh
@@ -15,9 +15,13 @@ HERE="$(cd "$(dirname "$0")/.." && pwd)"      # packaging/
 SRC="$HERE/mcpb"
 OUT="$HERE/dist"
 mkdir -p "$OUT"
-echo "validating manifest..."
-npx -y @anthropic-ai/mcpb validate "$SRC/manifest.json"
+# Pinned: an unpinned npx fetches whatever is latest at build time, so the same
+# git tag could produce a different bundle, and an upstream break or compromise
+# would land straight in a published artifact. Bump deliberately.
+MCPB_VERSION="${MCPB_VERSION:-2.1.2}"
+echo "validating manifest (mcpb $MCPB_VERSION)..."
+npx -y "@anthropic-ai/mcpb@$MCPB_VERSION" validate "$SRC/manifest.json"
 echo "packing..."
-npx -y @anthropic-ai/mcpb pack "$SRC" "$OUT/thingctx.mcpb"
+npx -y "@anthropic-ai/mcpb@$MCPB_VERSION" pack "$SRC" "$OUT/thingctx.mcpb"
 echo "built: $OUT/thingctx.mcpb"
 echo "next: submit to Anthropic's directory for review (they gate the curated list)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,10 @@ mqtt = ["paho-mqtt>=2.0"]
 # Validate TDs against the official W3C WoT TD 1.1 schema.
 validate = ["jsonschema>=4.0"]
 # Expose a Thing (or a whole fleet of TDs) to any MCP client.
-mcp = ["mcp>=1.2"]
+mcp = ["mcp>=1.3"]
 # Serve the bridge over streamable HTTP (thingctx-mcp --http) for a hosted gateway or
 # a cloud agent runtime that only takes a remote MCP URL. starlette ships with mcp.
-mcp-http = ["mcp>=1.2", "uvicorn>=0.27"]
+mcp-http = ["mcp>=1.3", "uvicorn>=0.27"]
 # Import OpenAPI specs (YAML support; JSON works without it).
 openapi = ["httpx>=0.25", "pyyaml>=6"]
 # Cloud auth: OAuth2 JWT-bearer assertions need RS256 JWT signing (pyjwt);
@@ -59,14 +59,14 @@ entra = ["azure-identity>=1.20", "pyjwt[crypto]>=2.8", "httpx>=0.27"]
 # still refuses every call until THINGCTX_FS_ROOT is set.
 filesystem = []
 # Everything.
-all = ["litellm>=1.0", "httpx>=0.27", "paho-mqtt>=2.0", "jsonschema>=4.0", "mcp>=1.2", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "av>=11", "numpy>=1.23", "pillow>=10"]
+all = ["litellm>=1.0", "httpx>=0.27", "paho-mqtt>=2.0", "jsonschema>=4.0", "mcp>=1.3", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "av>=11", "numpy>=1.23", "pillow>=10"]
 # The gate tools are pinned, not floated: the CI and the pre-commit hook must
 # agree with what a contributor runs locally, or "green here, red in CI" churn
 # follows. ruff 0.14.x is where the in-function-import rule (PLC0415) is stable.
 # botocore is here only as an independent oracle for the SigV4 signer: the test
 # compares our signature against botocore's canonical one. Without it installed
 # that comparison skips, so the signing code goes unchecked.
-dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.2", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13", "diff-cover==10.4.1"]
+dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.3", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13", "diff-cover==10.4.1"]
 
 [project.scripts]
 # Serve a Thing (or a whole fleet of TDs) to any MCP client.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,10 @@ mqtt = ["paho-mqtt>=2.0"]
 # Validate TDs against the official W3C WoT TD 1.1 schema.
 validate = ["jsonschema>=4.0"]
 # Expose a Thing (or a whole fleet of TDs) to any MCP client.
-mcp = ["mcp>=1.0"]
+mcp = ["mcp>=1.2"]
 # Serve the bridge over streamable HTTP (thingctx-mcp --http) for a hosted gateway or
 # a cloud agent runtime that only takes a remote MCP URL. starlette ships with mcp.
-mcp-http = ["mcp>=1.0", "uvicorn>=0.27"]
+mcp-http = ["mcp>=1.2", "uvicorn>=0.27"]
 # Import OpenAPI specs (YAML support; JSON works without it).
 openapi = ["httpx>=0.25", "pyyaml>=6"]
 # Cloud auth: OAuth2 JWT-bearer assertions need RS256 JWT signing (pyjwt);
@@ -59,14 +59,14 @@ entra = ["azure-identity>=1.20", "pyjwt[crypto]>=2.8", "httpx>=0.27"]
 # still refuses every call until THINGCTX_FS_ROOT is set.
 filesystem = []
 # Everything.
-all = ["litellm>=1.0", "httpx>=0.27", "paho-mqtt>=2.0", "jsonschema>=4.0", "mcp>=1.0", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "av>=11", "numpy>=1.23", "pillow>=10"]
+all = ["litellm>=1.0", "httpx>=0.27", "paho-mqtt>=2.0", "jsonschema>=4.0", "mcp>=1.2", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "av>=11", "numpy>=1.23", "pillow>=10"]
 # The gate tools are pinned, not floated: the CI and the pre-commit hook must
 # agree with what a contributor runs locally, or "green here, red in CI" churn
 # follows. ruff 0.14.x is where the in-function-import rule (PLC0415) is stable.
 # botocore is here only as an independent oracle for the SigV4 signer: the test
 # compares our signature against botocore's canonical one. Without it installed
 # that comparison skips, so the signing code goes unchecked.
-dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.0", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13", "diff-cover==10.4.1"]
+dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.2", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13", "diff-cover==10.4.1"]
 
 [project.scripts]
 # Serve a Thing (or a whole fleet of TDs) to any MCP client.

--- a/src/thingctx/integrations/mcp.py
+++ b/src/thingctx/integrations/mcp.py
@@ -82,6 +82,21 @@ _MAX_SNAPSHOT_FRAMES = 32
 _APPROVAL_TTL_S = 300.0
 
 
+def _thingctx_version() -> str:
+    """thingctx's own version, read from installed metadata.
+
+    Read here rather than imported from the package root, which this module
+    never imports, so the bridge cannot introduce an import cycle. An editable
+    checkout with no metadata still has to start, so fall back rather than raise.
+    """
+    from importlib.metadata import PackageNotFoundError, version  # noqa: PLC0415
+
+    try:
+        return version("thingctx")
+    except PackageNotFoundError:
+        return "unknown"
+
+
 def _credentials_from_env() -> dict[str, str]:
     """Collect per-Thing secrets from the environment.
 
@@ -248,7 +263,9 @@ def build_mcp_server(
         "raw code bypasses that protection. If a tool reports needs_approval, ask the "
         "user, and only on an explicit yes call approve with the token."
     )
-    server: Server = Server(name, instructions=_instructions)
+    # Report thingctx's version, not the SDK's. A host shows serverInfo in its
+    # logs and its UI, so without this a bug report names the MCP SDK release.
+    server: Server = Server(name, version=_thingctx_version(), instructions=_instructions)
     gateway = client.gateway() if tool_mode == "gateway" else None
     # The gateway's own ``subscribe_event`` returns a live stream, which a direct
     # Python caller can iterate but MCP cannot carry. So over MCP there is ONE

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -734,3 +734,17 @@ async def test_server_reports_thingctx_version_not_the_sdk():
         info = (await s.initialize()).serverInfo
     assert info.version == version("thingctx")
     assert info.version != version("mcp")
+
+
+def test_version_falls_back_when_metadata_is_absent(monkeypatch):
+    """A checkout with no installed metadata still has to start the bridge."""
+    pytest.importorskip("mcp")
+    import importlib.metadata as md
+
+    from thingctx.integrations import mcp as bridge
+
+    def _missing(_name: str) -> str:
+        raise md.PackageNotFoundError("thingctx")
+
+    monkeypatch.setattr(md, "version", _missing)
+    assert bridge._thingctx_version() == "unknown"

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -722,7 +722,7 @@ async def test_server_reports_thingctx_version_not_the_sdk():
     """A host shows serverInfo in its UI and logs, so a bug report from Claude
     Desktop must name thingctx's release, not whatever MCP SDK is installed."""
     pytest.importorskip("mcp")
-    from importlib.metadata import version
+    import importlib.metadata as md
 
     from mcp.shared.memory import create_connected_server_and_client_session as connect
 
@@ -732,8 +732,9 @@ async def test_server_reports_thingctx_version_not_the_sdk():
     server = build_mcp_server(ThingClient(tds=[TD], bindings=[inv]), name="pump", tool_mode="flat")
     async with connect(server) as s:
         info = (await s.initialize()).serverInfo
-    assert info.version == version("thingctx")
-    assert info.version != version("mcp")
+    # Only this assertion describes the behaviour. Comparing against the SDK
+    # version would fail the day the two releases happen to share a string.
+    assert info.version == md.version("thingctx")
 
 
 def test_version_falls_back_when_metadata_is_absent(monkeypatch):

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -716,3 +716,21 @@ async def test_media_snapshot_fills_href_urivariables_from_args():
         assert res.content[0].type == "image"
     # the uriVariables reached the backend filled, not as literal "{+host}"
     assert seen["url"] == "rtsp://10.0.0.5:8554/front"
+
+
+async def test_server_reports_thingctx_version_not_the_sdk():
+    """A host shows serverInfo in its UI and logs, so a bug report from Claude
+    Desktop must name thingctx's release, not whatever MCP SDK is installed."""
+    pytest.importorskip("mcp")
+    from importlib.metadata import version
+
+    from mcp.shared.memory import create_connected_server_and_client_session as connect
+
+    from thingctx.integrations.mcp import build_mcp_server
+
+    inv = LocalBinding({"status": lambda: {"rpm": 0}})
+    server = build_mcp_server(ThingClient(tds=[TD], bindings=[inv]), name="pump", tool_mode="flat")
+    async with connect(server) as s:
+        info = (await s.initialize()).serverInfo
+    assert info.version == version("thingctx")
+    assert info.version != version("mcp")

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -718,6 +718,7 @@ async def test_media_snapshot_fills_href_urivariables_from_args():
     assert seen["url"] == "rtsp://10.0.0.5:8554/front"
 
 
+@pytest.mark.asyncio
 async def test_server_reports_thingctx_version_not_the_sdk():
     """A host shows serverInfo in its UI and logs, so a bug report from Claude
     Desktop must name thingctx's release, not whatever MCP SDK is installed."""
@@ -754,3 +755,26 @@ def test_version_falls_back_when_metadata_is_absent(monkeypatch):
 
     monkeypatch.setattr(md, "version", _missing)
     assert bridge._thingctx_version() == "unknown"
+
+
+def test_declared_mcp_floor_supports_what_the_bridge_calls():
+    """The mcp extra's lower bound must be a version whose Server accepts every
+    argument build_mcp_server passes. The floor said >=1.0 for a long time while
+    mcp.server.lowlevel did not exist before 1.2 and instructions arrived in 1.3,
+    so the package promised a version the bridge could not import."""
+    pytest.importorskip("mcp")
+    import inspect
+    from pathlib import Path
+
+    import tomllib
+    from mcp.server.lowlevel import Server
+
+    accepted = set(inspect.signature(Server.__init__).parameters)
+    assert {"version", "instructions"} <= accepted
+
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    extras = tomllib.loads(pyproject.read_text())["project"]["optional-dependencies"]
+    floors = {
+        pin.split(">=")[1] for group in extras.values() for pin in group if pin.startswith("mcp>=")
+    }
+    assert floors == {"1.3"}, f"mcp floor drifted: {floors}"

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -732,9 +732,14 @@ async def test_server_reports_thingctx_version_not_the_sdk():
     server = build_mcp_server(ThingClient(tds=[TD], bindings=[inv]), name="pump", tool_mode="flat")
     async with connect(server) as s:
         info = (await s.initialize()).serverInfo
-    # Only this assertion describes the behaviour. Comparing against the SDK
-    # version would fail the day the two releases happen to share a string.
-    assert info.version == md.version("thingctx")
+    # Expected with the same fallback the bridge uses, so a source checkout with
+    # no installed metadata still runs this. Comparing against the SDK version
+    # would fail the day the two releases happen to share a string.
+    try:
+        expected = md.version("thingctx")
+    except md.PackageNotFoundError:
+        expected = "unknown"
+    assert info.version == expected
 
 
 def test_version_falls_back_when_metadata_is_absent(monkeypatch):

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -755,26 +755,3 @@ def test_version_falls_back_when_metadata_is_absent(monkeypatch):
 
     monkeypatch.setattr(md, "version", _missing)
     assert bridge._thingctx_version() == "unknown"
-
-
-def test_declared_mcp_floor_supports_what_the_bridge_calls():
-    """The mcp extra's lower bound must be a version whose Server accepts every
-    argument build_mcp_server passes. The floor said >=1.0 for a long time while
-    mcp.server.lowlevel did not exist before 1.2 and instructions arrived in 1.3,
-    so the package promised a version the bridge could not import."""
-    pytest.importorskip("mcp")
-    import inspect
-    from pathlib import Path
-
-    import tomllib
-    from mcp.server.lowlevel import Server
-
-    accepted = set(inspect.signature(Server.__init__).parameters)
-    assert {"version", "instructions"} <= accepted
-
-    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    extras = tomllib.loads(pyproject.read_text())["project"]["optional-dependencies"]
-    floors = {
-        pin.split(">=")[1] for group in extras.values() for pin in group if pin.startswith("mcp>=")
-    }
-    assert floors == {"1.3"}, f"mcp floor drifted: {floors}"

--- a/tests/test_packaging_floors.py
+++ b/tests/test_packaging_floors.py
@@ -25,8 +25,10 @@ def _declared_floors(package: str) -> set[str]:
     Read with a regex rather than tomllib, which is 3.11+ and this suite runs on
     3.10.
     """
+    # Capture only the version, so adding an upper bound later ("mcp>=1.3,<2")
+    # narrows the pin rather than turning this into a confusing failure.
     text = _PYPROJECT.read_text()
-    return set(re.findall(rf'"{re.escape(package)}>=([0-9][^"]*)"', text))
+    return set(re.findall(rf'"{re.escape(package)}>=([0-9][0-9.]*)', text))
 
 
 @pytest.mark.skipif(not _PYPROJECT.exists(), reason="runs against the source tree")

--- a/tests/test_packaging_floors.py
+++ b/tests/test_packaging_floors.py
@@ -30,19 +30,23 @@ def _declared_floors(package: str) -> set[str]:
 
 
 @pytest.mark.skipif(not _PYPROJECT.exists(), reason="runs against the source tree")
-def test_mcp_floor_matches_what_the_bridge_calls():
+def test_every_mcp_pin_declares_the_same_floor():
+    """Reading the pins needs no SDK, so this must not hide behind an importorskip:
+    the guard is worth least on the machine that happens to have mcp installed."""
+    assert _declared_floors("mcp") == {"1.3"}, (
+        "every mcp pin must declare the floor the bridge actually builds on"
+    )
+
+
+def test_installed_mcp_accepts_what_the_bridge_passes():
     pytest.importorskip("mcp")
     import inspect
 
     from mcp.server.lowlevel import Server
 
     # Both are passed by build_mcp_server. instructions is the later of the two,
-    # so the floor is the release that has it.
+    # so the floor above is the release that has it.
     accepted = set(inspect.signature(Server.__init__).parameters)
     assert {"version", "instructions"} <= accepted, (
         f"the installed mcp is missing {sorted({'version', 'instructions'} - accepted)}"
-    )
-
-    assert _declared_floors("mcp") == {"1.3"}, (
-        "every mcp pin must declare the floor the bridge actually builds on"
     )

--- a/tests/test_packaging_floors.py
+++ b/tests/test_packaging_floors.py
@@ -1,0 +1,48 @@
+# Copyright 2026 The thingctx Authors
+# SPDX-License-Identifier: Apache-2.0
+"""The declared dependency floors have to match what the code actually calls.
+
+A lower bound is a promise. thingctx carried ``mcp>=1.0`` for a long time while
+``mcp.server.lowlevel`` did not exist before 1.2 and ``instructions`` arrived in
+1.3, so the package promised a version the bridge could not even import. Nothing
+caught it because the floor is only exercised when someone installs the oldest
+allowed release, which CI never does.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _declared_floors(package: str) -> set[str]:
+    """Every lower bound pinned for ``package`` across the extras.
+
+    Read with a regex rather than tomllib, which is 3.11+ and this suite runs on
+    3.10.
+    """
+    text = _PYPROJECT.read_text()
+    return set(re.findall(rf'"{re.escape(package)}>=([0-9][^"]*)"', text))
+
+
+@pytest.mark.skipif(not _PYPROJECT.exists(), reason="runs against the source tree")
+def test_mcp_floor_matches_what_the_bridge_calls():
+    pytest.importorskip("mcp")
+    import inspect
+
+    from mcp.server.lowlevel import Server
+
+    # Both are passed by build_mcp_server. instructions is the later of the two,
+    # so the floor is the release that has it.
+    accepted = set(inspect.signature(Server.__init__).parameters)
+    assert {"version", "instructions"} <= accepted, (
+        f"the installed mcp is missing {sorted({'version', 'instructions'} - accepted)}"
+    )
+
+    assert _declared_floors("mcp") == {"1.3"}, (
+        "every mcp pin must declare the floor the bridge actually builds on"
+    )


### PR DESCRIPTION
Builds the Claude Desktop bundle as part of the release, before the publish gate.

Until now the release published a wheel and attached only `dist/*`. The `.mcpb` bundle, which is the artifact most users actually install, was never built by a tag, never verified, and never reached the GitHub Release. `packaging/scripts/build-mcpb.sh` existed but nothing called it.

It now builds after the smoke installs and before the PyPI gate, and uploads as a workflow artifact. A paused run therefore already carries an installable bundle you can download and dogfood while the publish is still held. It is attached to the GitHub Release as well.

A guard fails the job when `manifest.json` and the tag disagree. Without it a release could ship a bundle claiming a different version than the wheel.

One ordering note worth stating plainly: the bundle is a launcher, not a vendored install. `uv` resolves thingctx from PyPI at first launch, so the bundle cannot be driven end to end until the publish is approved. Building it early still catches a bad manifest or a failed pack while the gate is closed, which is the part that can be checked without PyPI.

Verified locally: the bundle builds (3 files, 4 KB, manifest validates), the workflow YAML parses, the job graph is build -> testpypi -> smoke -> bundle -> pypi -> github-release, and the version guard passes against the real tag.
