### PR TITLE
fix(release): fail on a reused TestPyPI version instead of skipping it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,11 @@ jobs:
           # `|| true` matters: under bash -e -o pipefail a failed curl kills the
           # step at this assignment, so the case below never runs and the release
           # dies with a bare curl error instead of the message that names the fix.
+          # stderr stays on the log: -S is here so a DNS, TLS or proxy failure is
+          # readable in CI rather than reduced to a bare 000.
           CODE=$(curl -sS -o /dev/null -w '%{http_code}\n' \
                    --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 \
-                   "https://test.pypi.org/pypi/thingctx/${VERSION}/json" 2>/dev/null \
+                   "https://test.pypi.org/pypi/thingctx/${VERSION}/json" \
                  | tail -n1 || true)
           CODE="${CODE:-000}"
           case "$CODE" in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,22 @@ jobs:
         with:
           name: dist
           path: dist/
+      # Refuse a version TestPyPI already has, rather than skipping the upload.
+      # TestPyPI cannot delete, so a reused version silently keeps the OLD build
+      # and every job after this one then validates an artifact that is not the
+      # one just built. A duplicate has to stop the release, not pass it.
+      - name: Refuse to reuse a version already on TestPyPI
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if curl -sf "https://test.pypi.org/pypi/thingctx/${VERSION}/json" >/dev/null; then
+            echo "::error::thingctx ${VERSION} is already on TestPyPI, so this run" \
+                 "would verify that older build. Tag a new version (an rc is fine)."
+            exit 1
+          fi
+          echo "${VERSION} is free on TestPyPI"
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
 
   # Prove the *published* TestPyPI artifact is installable on every supported
   # Python and that the offline suite passes against it, not the local tree.
@@ -120,14 +132,17 @@ jobs:
       - name: Bundle version must match the release tag
         run: |
           TAG="${GITHUB_REF_NAME#v}"
+          # A prerelease still ships the release it is a candidate for, so compare
+          # against the release version: v0.2.0rc1 must match a 0.2.0 manifest.
+          RELEASE="${TAG%%[-abcr]*}"
           # node, not python3: this job already sets node up for the packer, so
           # reading the manifest with it avoids depending on the runner's python.
           MANIFEST=$(node -p "require('./packaging/mcpb/manifest.json').version")
-          if [ "$TAG" != "$MANIFEST" ]; then
-            echo "::error::manifest.json says $MANIFEST, tag says $TAG"
+          if [ "$RELEASE" != "$MANIFEST" ]; then
+            echo "::error::manifest.json says $MANIFEST, tag says $TAG (release $RELEASE)"
             exit 1
           fi
-          echo "bundle version $MANIFEST matches the tag"
+          echo "bundle version $MANIFEST matches tag $TAG"
       - run: bash packaging/scripts/build-mcpb.sh
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,14 @@ jobs:
           # Bounded and retried: an unbounded curl here can wedge the whole
           # release on a DNS or TLS stall. A 404 is the answer we want, so treat
           # only a real HTTP response as authoritative and fail closed otherwise.
-          # --write-out prints once per attempt, so keep the last line only.
+          # --write-out prints once per attempt, so keep the last line only. The
+          # `|| true` matters: under bash -e -o pipefail a failed curl kills the
+          # step at this assignment, so the case below never runs and the release
+          # dies with a bare curl error instead of the message that names the fix.
           CODE=$(curl -sS -o /dev/null -w '%{http_code}\n' \
                    --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 \
                    "https://test.pypi.org/pypi/thingctx/${VERSION}/json" 2>/dev/null \
-                 | tail -n1)
+                 | tail -n1 || true)
           CODE="${CODE:-000}"
           case "$CODE" in
             404) echo "${VERSION} is free on TestPyPI" ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,25 @@ jobs:
       - name: Refuse to reuse a version already on TestPyPI
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          if curl -sf "https://test.pypi.org/pypi/thingctx/${VERSION}/json" >/dev/null; then
-            echo "::error::thingctx ${VERSION} is already on TestPyPI, so this run" \
-                 "would verify that older build. Tag a new version (an rc is fine)."
-            exit 1
-          fi
-          echo "${VERSION} is free on TestPyPI"
+          # Bounded and retried: an unbounded curl here can wedge the whole
+          # release on a DNS or TLS stall. A 404 is the answer we want, so treat
+          # only a real HTTP response as authoritative and fail closed otherwise.
+          # --write-out prints once per attempt, so keep the last line only.
+          CODE=$(curl -sS -o /dev/null -w '%{http_code}\n' \
+                   --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 \
+                   "https://test.pypi.org/pypi/thingctx/${VERSION}/json" 2>/dev/null \
+                 | tail -n1)
+          CODE="${CODE:-000}"
+          case "$CODE" in
+            404) echo "${VERSION} is free on TestPyPI" ;;
+            200)
+              echo "::error::thingctx ${VERSION} is already on TestPyPI, so this run" \
+                   "would verify that older build. Tag a new version (an rc is fine)."
+              exit 1 ;;
+            *)
+              echo "::error::could not reach TestPyPI to check ${VERSION} (HTTP ${CODE})."
+              exit 1 ;;
+          esac
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -134,7 +147,9 @@ jobs:
           TAG="${GITHUB_REF_NAME#v}"
           # A prerelease still ships the release it is a candidate for, so compare
           # against the release version: v0.2.0rc1 must match a 0.2.0 manifest.
-          RELEASE="${TAG%%[-abcr]*}"
+          # Only the PEP 440 prerelease markers are stripped. A tag like
+          # 0.2.0release1 is not a prerelease of anything and must not pass.
+          RELEASE=$(printf '%s' "$TAG" | sed -E 's/(a|b|rc)[0-9]+$//')
           # node, not python3: this job already sets node up for the packer, so
           # reading the manifest with it avoids depending on the runner's python.
           MANIFEST=$(node -p "require('./packaging/mcpb/manifest.json').version")

--- a/tests/test_media_binding.py
+++ b/tests/test_media_binding.py
@@ -23,8 +23,9 @@ class _FakeBackend:
         self.count = count
         self.raise_at = raise_at
         self.stopped = False
-        # Set on the worker thread when it observes stop. A test can wait on this
-        # instead of polling the bool, which is what a loaded machine loses.
+        # Set on the worker thread when it observes stop. The worker has to be
+        # scheduled once more to get there, and a loaded machine gives no promise
+        # about when, so a test waits on this rather than polling stopped.
         self.stopped_event = threading.Event()
         self.seen_options: dict | None = None
 

--- a/tests/test_media_binding.py
+++ b/tests/test_media_binding.py
@@ -23,6 +23,9 @@ class _FakeBackend:
         self.count = count
         self.raise_at = raise_at
         self.stopped = False
+        # Set on the worker thread when it observes stop. A test can wait on this
+        # instead of polling the bool, which is what a loaded machine loses.
+        self.stopped_event = threading.Event()
         self.seen_options: dict | None = None
 
     def can_open(self, url: str, hint: dict) -> bool:
@@ -34,6 +37,7 @@ class _FakeBackend:
         for i in range(self.count):
             if stop.is_set():
                 self.stopped = True
+                self.stopped_event.set()
                 return
             if self.raise_at is not None and i == self.raise_at:
                 raise RuntimeError("decode boom")
@@ -122,13 +126,10 @@ def test_early_break_sets_stop():
     inv = MediaBinding(backends=[fake], max_queue=2)
     frames = asyncio.run(_collect(inv, _form(), limit=3))
     assert len(frames) == 3
-    # the worker observes stop shortly after the consumer leaves the loop
-    for _ in range(100):
-        if fake.stopped:
-            break
-        import time
-
-        time.sleep(0.01)
+    # Wait on the worker rather than poll for a second: the thread has to be
+    # scheduled once more to see stop, and a loaded machine does not promise that
+    # inside a fixed window. The generous timeout only bounds a real hang.
+    assert fake.stopped_event.wait(timeout=30), "worker never observed stop"
     assert fake.stopped
 
 


### PR DESCRIPTION
Fixes a way the release can go green while publishing nothing.

`skip-existing: true` on the TestPyPI publish turned a version collision into a silent success. The `v0.2.0` run hit exactly this: TestPyPI answered `400 File already exists`, the publish job reported success having uploaded nothing, and all three smoke jobs then installed and validated the **older** build from an earlier tag attempt. They failed on `assert '1.28.1' == '0.2.0'` and a missing `_thingctx_version`, which is the smoke stage correctly reporting that it was handed the wrong artifact.

The flag exists so a re run does not fail on a duplicate. The cost is worse than the problem: TestPyPI cannot delete, so a reused version means every downstream job verifies something other than what was just built. A duplicate now fails before the upload, with a message that names the fix.

The bundle guard also compares the release version rather than the raw tag, so `v0.2.0rc1` matches a `0.2.0` manifest. That is what makes a prerelease dry run possible at all, and it is verified against `0.2.0`, `0.2.0rc1`, `0.2.0a1`, `0.2.0b2`, `0.2.1` and `0.10.0rc3`.

Verified: the check returns TAKEN for `0.2.0` (which is stale on TestPyPI and would have been skipped) and free for `0.2.0rc1`. Real PyPI is untouched at 0.1.3.
