### PR TITLE
release: 0.2.0rc1, and check the built version rather than the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,18 @@ jobs:
       # one just built. A duplicate has to stop the release, not pass it.
       - name: Refuse to reuse a version already on TestPyPI
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          # Read the version off the built wheel, not the tag. A tag does not
+          # change pyproject.toml, so checking the tag would clear a version
+          # while the upload carries a different one, which is how v0.2.0rc1
+          # sailed past this check and then failed on a duplicate 0.2.0.
+          WHEEL=$(ls dist/*.whl | head -n1)
+          VERSION=$(basename "$WHEEL" | cut -d- -f2)
+          echo "built wheel is version ${VERSION} (tag ${GITHUB_REF_NAME})"
+          if [ "${VERSION}" != "${GITHUB_REF_NAME#v}" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} builds version ${VERSION}." \
+                 "Set the version in pyproject.toml and __init__.py to match the tag."
+            exit 1
+          fi
           # Bounded and retried: an unbounded curl here can wedge the whole
           # release on a DNS or TLS stall. A 404 is the answer we want, so treat
           # only a real HTTP response as authoritative and fail closed otherwise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thingctx"
-version = "0.2.0"
+version = "0.2.0rc1"
 description = "Drive any agent against any W3C WoT Thing, over any transport. No per-integration server."
 readme = "README-pypi.md"
 requires-python = ">=3.10"

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -132,7 +132,7 @@ from thingctx.trust import (
 )
 from thingctx.validate import TDValidationError, validate_td
 
-__version__ = "0.2.0"
+__version__ = "0.2.0rc1"
 
 __all__ = [
     "BUILTIN_BINDINGS",


### PR DESCRIPTION
Cuts `0.2.0rc1` so the release pipeline can be exercised end to end against a genuinely fresh artifact.

TestPyPI already holds a stale `0.2.0` from this morning's first tag attempt and cannot delete, so a `v0.2.0` run can never verify a current build there. A release candidate is the normal way through: `pip install thingctx` ignores prereleases by default, so this is invisible to ordinary users.

The `v0.2.0rc1` tag alone was not enough. Nothing derives the package version from the tag, so `build` read `pyproject.toml` and produced `thingctx-0.2.0.whl` again, which TestPyPI rejected as a duplicate. The version probe had cleared `0.2.0rc1`, a version that was never being uploaded.

So the probe now reads the version off the built wheel instead of the tag, and fails when the two disagree, naming the two files to edit. Verified: the built wheel is `thingctx-0.2.0rc1`, the guard passes for `v0.2.0rc1` and would have failed for `v0.2.0`.

The bundle guard needed no change; it already strips the prerelease marker, so a `0.2.0rc1` tag matches the `0.2.0` manifest.
