### PR TITLE
fix(bundle): pin the exact release, and flag a candidate as a prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,16 @@ jobs:
         with:
           name: mcpb
           path: dist/
+      # A candidate must not sit on the repo front page as the latest release.
+      - name: Is this tag a prerelease
+        id: kind
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            *a[0-9]*|*b[0-9]*|*rc[0-9]*) echo "pre=true"  >> "$GITHUB_OUTPUT" ;;
+            *)                           echo "pre=false" >> "$GITHUB_OUTPUT" ;;
+          esac
       - uses: softprops/action-gh-release@c12583777ecdfd3be55c69cf75464299dc01057e # v3
         with:
           generate_release_notes: true
+          prerelease: ${{ steps.kind.outputs.pre }}
           files: dist/*

--- a/packaging/mcpb/INSTALL.md
+++ b/packaging/mcpb/INSTALL.md
@@ -7,11 +7,16 @@ first launch.
 
 ## Before you start
 
-Claude Desktop, and [uv](https://docs.astral.sh/uv/) on your PATH. Desktop runs
-`uv run` to start the server, so an install it cannot find fails with nothing
-useful in the log.
+Claude Desktop, and [uv](https://docs.astral.sh/uv/).
 
     uv --version
+
+The bundle looks for `uv` in the three places it normally lands: `/usr/local/bin`,
+`/opt/homebrew/bin`, and `~/.local/bin`, which is where the standalone installer
+puts it. Desktop starts the server with a minimal PATH that does not include your
+shell profile, so somewhere else means it will not be found, and the only symptom
+is "Unable to connect to extension server". If `uv` lives somewhere unusual, link
+it into one of those three.
 
 ## Install
 

--- a/packaging/mcpb/INSTALL.md
+++ b/packaging/mcpb/INSTALL.md
@@ -1,0 +1,75 @@
+# Install the thingctx bundle in Claude Desktop
+
+The bundle gives Claude Desktop a set of tools built from Thing Descriptions, and
+puts a policy gate in front of every call. It is a launcher, not a copy of
+thingctx: three small files, no vendored code. `uv` installs thingctx itself on
+first launch.
+
+## Before you start
+
+Claude Desktop, and [uv](https://docs.astral.sh/uv/) on your PATH. Desktop runs
+`uv run` to start the server, so an install it cannot find fails with nothing
+useful in the log.
+
+    uv --version
+
+## Install
+
+1. Download `thingctx.mcpb`.
+2. Open Claude Desktop, go to Settings, then Extensions.
+3. Drag the `.mcpb` onto the window, or use Install from file.
+4. Answer the four questions below.
+5. Quit Claude Desktop completely and reopen it. Not just the window: the server
+   starts with the app, so a reload will not pick up a config change.
+
+First launch takes a minute or two while `uv` resolves the dependencies. The
+media extra pulls PyAV and numpy, which are large.
+
+## What it asks you
+
+**Things** is the only required answer. It takes a TD Directory URL, a folder of
+Thing Descriptions, or a single TD file. The default is the hosted registry,
+which is the fastest way to see it work. Point it at your own folder when you
+have one.
+
+**Policy** decides what the tools may do at all. `read-only`, the default, allows
+reads, subscriptions and actions the description marks safe. `full` allows
+everything the Things declare.
+
+**Approve when** decides what needs your say so. `destructive`, the default, asks
+before any write or non idempotent action. `declared` asks only for actions the
+description marks risky. `all` asks every time. `never` disables the prompt, which
+also means nothing stops a mistake.
+
+**Filesystem root** is empty by default, and while it is empty every filesystem
+call is refused. Set it only when you want the filesystem Thing, and set it to
+the narrowest directory that works.
+
+## Check it worked
+
+Ask Claude what tools it has. You should see names shaped `<thing>__<action>`,
+like `time__getCurrentTime`.
+
+Then ask it for something harmless, a current time or a status read, and confirm
+you get a real answer.
+
+Then ask for something that changes state. With the default policy you should be
+asked to approve first. If it goes through without asking, the gate is not doing
+its job and that is worth reporting.
+
+## When it does not work
+
+**The extension is there but has no tools.** Almost always the Things setting:
+a URL that does not serve JSON, or a folder with no `.td.json` in it. Check the
+value resolves in a browser.
+
+**Nothing appears at all.** Usually `uv` is not on the PATH Desktop sees, which
+is not always the PATH your shell has. The Desktop MCP log names the failure.
+
+**It worked and then stopped.** If you changed a setting, quit and reopen the app
+rather than reloading.
+
+## Removing it
+
+Settings, Extensions, remove. Nothing is left behind except the packages `uv`
+cached.

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -33,7 +33,8 @@
       "env": {
         "THINGCTX_APPROVE_WHEN": "${user_config.approve_when}",
         "THINGCTX_POLICY": "${user_config.policy}",
-        "THINGCTX_FS_ROOT": "${user_config.fs_root}"
+        "THINGCTX_FS_ROOT": "${user_config.fs_root}",
+        "PATH": "/usr/local/bin:/opt/homebrew/bin:${HOME}/.local/bin:${PATH}"
       }
     }
   },

--- a/packaging/scripts/build-mcpb.sh
+++ b/packaging/scripts/build-mcpb.sh
@@ -14,7 +14,44 @@ set -euo pipefail
 HERE="$(cd "$(dirname "$0")/.." && pwd)"      # packaging/
 SRC="$HERE/mcpb"
 OUT="$HERE/dist"
+ROOT="$(cd "$HERE/.." && pwd)"
 mkdir -p "$OUT"
+
+# The bundle asks for exactly the release it ships with, taken from
+# pyproject.toml. A range would leave the resolver to choose, and a range like
+# >=0.2,<0.3 silently excludes a prerelease, so an rc bundle cannot install the
+# rc it was built for. Stamping the exact version removes the guesswork: what a
+# user launches is the build this bundle was tested against.
+VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' "$ROOT/pyproject.toml" | head -n1)
+if [ -z "$VERSION" ]; then
+  echo "could not read the version from $ROOT/pyproject.toml" >&2
+  exit 1
+fi
+EXTRAS="mcp,http,mqtt,media,filesystem,authz"
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+cp -R "$SRC/." "$STAGE/"
+python3 - "$STAGE" "$VERSION" "$EXTRAS" <<'PY'
+import json, pathlib, re, sys
+stage, version, extras = pathlib.Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+
+pin = pathlib.Path(stage / "pyproject.toml")
+text = pin.read_text()
+new, count = re.subn(
+    r'"thingctx\[[^\]]*\][^"]*"', f'"thingctx[{extras}]=={version}"', text
+)
+if count != 1:
+    raise SystemExit(f"expected one thingctx pin in pyproject.toml, found {count}")
+pin.write_text(new)
+
+manifest = pathlib.Path(stage / "manifest.json")
+data = json.loads(manifest.read_text())
+data["version"] = version
+manifest.write_text(json.dumps(data, indent=2) + "\n")
+print(f"stamped bundle for thingctx=={version}")
+PY
+SRC="$STAGE"
 # Pinned: an unpinned npx fetches whatever is latest at build time, so the same
 # git tag could produce a different bundle, and an upstream break or compromise
 # would land straight in a published artifact. Bump deliberately.


### PR DESCRIPTION
The bundle now asks for the exact release it ships with, instead of a range.

`>=0.2,<0.3` left the resolver to choose, and a plain range excludes prereleases, so the `0.2.0rc1` bundle could not install the `0.2.0rc1` it was built for. None of uv's prerelease switches help: `[tool.uv] prerelease = "allow"`, `--prerelease=allow` and `UV_PRERELEASE=allow` were all tested and all refused, because the range itself is what excludes it. An exact pin resolves with no flags, no environment variables and no coaxing.

So the build stamps the version and the dependency from `pyproject.toml` into a temp copy before packing. What a user launches is the build the bundle was tested against, and the source files no longer carry a version anyone has to remember to update. Verified: the built bundle pins `==0.2.0rc1` with a matching manifest, the source files are untouched, and `uv run` resolves and imports the entry point.

The GitHub Release also marked `v0.2.0rc1` as the latest release, so a candidate sat on the repo front page. The tag now decides that, checked against `v0.2.0`, `rc1`, `rc2`, `a1`, `b2`, `0.2.1` and `0.10.0rc3`. I already corrected the existing release by hand.

Adds `packaging/mcpb/INSTALL.md`. Installing needs uv on PATH and a full restart, and neither is obvious from the failure you get without them.
