### PR TITLE
release: 0.2.0

### DIFF
--- a/packaging/scripts/publish-registry.sh
+++ b/packaging/scripts/publish-registry.sh
@@ -6,8 +6,32 @@
 # Prereqs: the mcp-publisher CLI, authenticated as the thingctx GitHub org.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
 ENTRY="$HERE/registry/server.json"
+
+# The entry carries the version twice and neither is generated, so a hand edit
+# that misses one publishes a listing that installs a different release than it
+# claims. Stamp both from pyproject.toml, the same source the bundle uses, and
+# publish from a temp copy so the tree keeps whatever is committed.
+VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' "$ROOT/pyproject.toml" | head -n1)
+if [ -z "$VERSION" ]; then
+  echo "could not read the version from $ROOT/pyproject.toml" >&2
+  exit 1
+fi
+STAMPED="$(mktemp -d)/server.json"
+trap 'rm -rf "$(dirname "$STAMPED")"' EXIT
+python3 - "$ENTRY" "$STAMPED" "$VERSION" <<'PY'
+import json, sys
+src, dst, version = sys.argv[1], sys.argv[2], sys.argv[3]
+entry = json.load(open(src))
+entry["version"] = version
+for pkg in entry.get("packages", []):
+    pkg["version"] = version
+json.dump(entry, open(dst, "w"), indent=2)
+print(f"stamped registry entry for thingctx=={version}")
+PY
+
 echo "dry-run against the registry..."
-mcp-publisher publish --dry-run "$ENTRY"
+mcp-publisher publish --dry-run "$STAMPED"
 echo "--- review the dry-run above; re-run without --dry-run to publish ---"
-# mcp-publisher publish "$ENTRY"
+# mcp-publisher publish "$STAMPED"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thingctx"
-version = "0.2.0rc1"
+version = "0.2.0"
 description = "Drive any agent against any W3C WoT Thing, over any transport. No per-integration server."
 readme = "README-pypi.md"
 requires-python = ">=3.10"

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -132,7 +132,7 @@ from thingctx.trust import (
 )
 from thingctx.validate import TDValidationError, validate_td
 
-__version__ = "0.2.0rc1"
+__version__ = "0.2.0"
 
 __all__ = [
     "BUILTIN_BINDINGS",


### PR DESCRIPTION
Bumps `pyproject.toml` and `__init__.py` from `0.2.0rc1` to `0.2.0`. The release workflow reads the version off the built wheel and refuses a tag that disagrees, so both had to move together.

Also stamps the MCP registry entry. `packaging/registry/server.json` carries the version twice and neither was generated, so a hand edit that missed one would publish a listing that installs a different release than it names. Both fields are now stamped from `pyproject.toml` at publish time, matching what the bundle already does, and the entry publishes from a temp copy so the tree keeps what is committed.

Verified: the two versions agree, the packaging floor guard passes, and the stamped entry keeps its identifier, its 3 package arguments, and its 3 environment variables.