### PR TITLE
release: 0.2.1

### DIFF
--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "thingctx",
   "display_name": "thingctx",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Drive any agent against any W3C WoT Thing from its description. The agent never holds your keys; you gate what it is allowed to do.",
   "author": {
     "name": "The thingctx Authors",

--- a/packaging/mcpb/pyproject.toml
+++ b/packaging/mcpb/pyproject.toml
@@ -2,7 +2,7 @@
 # with uv at first launch; nothing is vendored in the bundle itself.
 [project]
 name = "thingctx-bundle"
-version = "0.2.0"
+version = "0.2.1"
 description = "Claude Desktop bundle launcher for the thingctx MCP bridge"
 requires-python = ">=3.10"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thingctx"
-version = "0.2.0"
+version = "0.2.1"
 description = "Drive any agent against any W3C WoT Thing, over any transport. No per-integration server."
 readme = "README-pypi.md"
 requires-python = ">=3.10"

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -132,7 +132,7 @@ from thingctx.trust import (
 )
 from thingctx.validate import TDValidationError, validate_td
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     "BUILTIN_BINDINGS",


### PR DESCRIPTION
Moves the release to 0.2.1.

0.2.0 reached the test index from a run that later failed, and a test index cannot replace a file. Reusing the version would mean every check after the upload validates that earlier artifact rather than the one just built, which is the failure the version check exists to catch. Moving to the next version keeps the check intact.

Four versions move together: `pyproject.toml`, `__init__.py`, the bundle manifest (the bundle job compares it against the tag), and the bundle launcher's own version. The dependency pin and the registry entry are stamped at build time and needed no edit.

Verified: 0.2.1 is unused on both indexes, and a rebuilt bundle packs `thingctx[...]==0.2.1` with a passing manifest validation.