### PR TITLE
fix(packaging): meet the registry schema and name a support channel

### DIFF
--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -116,5 +116,10 @@
       "default": "",
       "required": false
     }
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thingctx/thingctx"
+  },
+  "support": "https://github.com/thingctx/thingctx/issues"
 }

--- a/packaging/registry/server.json
+++ b/packaging/registry/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.thingctx/thingctx",
-  "description": "Drive any agent against any W3C WoT Thing from its description. The agent never holds your keys; you gate what it is allowed to do.",
+  "description": "Drive devices and APIs from their W3C Thing Description. You gate every operation.",
   "repository": {
     "url": "https://github.com/thingctx/thingctx",
     "source": "github"
@@ -14,11 +14,20 @@
       "registryBaseUrl": "https://pypi.org",
       "identifier": "thingctx",
       "version": "0.2.0",
-      "transport": { "type": "stdio" },
+      "transport": {
+        "type": "stdio"
+      },
       "runtimeHint": "uvx",
       "packageArguments": [
-        { "type": "named", "name": "--from", "value": "thingctx[mcp,http,mqtt,media,filesystem,authz]" },
-        { "type": "positional", "value": "thingctx-mcp" },
+        {
+          "type": "named",
+          "name": "--from",
+          "value": "thingctx[mcp,http,mqtt,media,filesystem,authz]"
+        },
+        {
+          "type": "positional",
+          "value": "thingctx-mcp"
+        },
         {
           "type": "positional",
           "valueHint": "tds",

--- a/packaging/scripts/publish-registry.sh
+++ b/packaging/scripts/publish-registry.sh
@@ -31,7 +31,9 @@ json.dump(entry, open(dst, "w"), indent=2)
 print(f"stamped registry entry for thingctx=={version}")
 PY
 
-echo "dry-run against the registry..."
-mcp-publisher publish --dry-run "$STAMPED"
+# The publisher resolves a bare server.json against the working directory, so
+# run it from the stamped copy's own directory rather than passing a path.
+echo "dry-run against the registry (login first: mcp-publisher login github)..."
+(cd "$(dirname "$STAMPED")" && mcp-publisher publish --dry-run server.json)
 echo "--- review the dry-run above; re-run without --dry-run to publish ---"
-# mcp-publisher publish "$STAMPED"
+# (cd "$(dirname "$STAMPED")" && mcp-publisher publish server.json)


### PR DESCRIPTION
Publishing the registry entry failed on two things that only show up when the publisher actually runs.

The registry caps `description` at 100 characters and the entry was 128, so the publish would have been rejected outright. Rewritten to 82 characters, leading with what it drives rather than the spec name.

The publisher resolves a bare `server.json` against the working directory, so passing a path to the stamped temp copy made it report the file as missing. It now runs from that copy's own directory.

The bundle manifest gains `repository` and `support`, the links a directory listing is expected to carry.

Verified: the stamped entry validates against its published schema with both version fields at 0.2.1, and `mcpb validate` passes on the manifest.