### PR TITLE
release: 0.2.2, and claim the package for the registry listing

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -73,3 +73,7 @@ folder of descriptions:
 Full README, examples, and design notes: https://github.com/thingctx/thingctx
 
 Apache-2.0
+
+<!-- The MCP registry reads this line to confirm the listing and this package
+     have the same owner. -->
+mcp-name: com.thingctx/thingctx

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "thingctx",
   "display_name": "thingctx",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Drive any agent against any W3C WoT Thing from its description. The agent never holds your keys; you gate what it is allowed to do.",
   "author": {
     "name": "The thingctx Authors",

--- a/packaging/mcpb/pyproject.toml
+++ b/packaging/mcpb/pyproject.toml
@@ -2,7 +2,7 @@
 # with uv at first launch; nothing is vendored in the bundle itself.
 [project]
 name = "thingctx-bundle"
-version = "0.2.1"
+version = "0.2.2"
 description = "Claude Desktop bundle launcher for the thingctx MCP bridge"
 requires-python = ">=3.10"
 dependencies = [

--- a/packaging/registry/PUBLISHING.md
+++ b/packaging/registry/PUBLISHING.md
@@ -1,0 +1,49 @@
+# Publishing the MCP registry entry
+
+The entry lists thingctx in the MCP registry, which feeds github.com/mcp and the
+VS Code `@mcp` gallery. It points at the PyPI release, so publish it only after
+that release exists.
+
+## Why a GitHub login is not enough
+
+The entry is named `com.thingctx/thingctx`. That is a domain namespace, and the
+registry proves those by DNS. A GitHub login grants only `io.github.<account>/*`,
+so publishing with one fails:
+
+    403 Forbidden
+    You have permission to publish: io.github.galaxygrid/*
+    Attempting to publish: com.thingctx/thingctx
+
+Keeping the `com.thingctx` name means authenticating against the domain. The
+alternative is renaming the entry to `io.github.<account>/thingctx`, which
+publishes with a GitHub login but ties the listing to a personal namespace
+rather than the project's own.
+
+## The TXT record
+
+It goes on the **apex**, `thingctx.com` itself. Not on a subdomain: the registry
+treats `_mcp-auth` and `_mcp-registry` as commonly mistaken selectors and will
+tell you the record is in the wrong place.
+
+    name:  thingctx.com        (or "@")
+    type:  TXT
+    value: v=MCPv1; k=ed25519; p=<base64 public key>
+
+A domain can hold several TXT records, so an existing SPF record stays.
+
+Generate the keypair with `openssl genpkey -algorithm ed25519`. The private key
+is a credential: it authorizes publishing under `com.thingctx/*`. Keep it out of
+the repo, and use a KMS signing provider instead if it needs to live in CI.
+
+## Publishing
+
+    mcp-publisher login dns --domain thingctx.com --private-key <hex>
+    bash packaging/scripts/publish-registry.sh              # dry run
+    bash packaging/scripts/publish-registry.sh --publish
+
+The script stamps the version from `pyproject.toml` into a temp copy, so the
+listed version always matches the release. That copy is deleted when the script
+exits, which is why the publish happens in the same run rather than as a
+separate step afterwards.
+
+Verify: <https://registry.modelcontextprotocol.io/v0/servers?search=thingctx>

--- a/packaging/scripts/publish-registry.sh
+++ b/packaging/scripts/publish-registry.sh
@@ -3,8 +3,18 @@
 # VS Code @mcp gallery. The entry is stdio + the uvx command -> it installs the
 # signed PyPI release. Publish AFTER the PyPI release exists and versions match.
 #
-# Prereqs: the mcp-publisher CLI, authenticated as the thingctx GitHub org.
+# Prereqs: the mcp-publisher CLI, authenticated as an owner of the thingctx
+# GitHub org (the registry checks org ownership of the com.thingctx namespace,
+# so repo admin rights alone are not enough): mcp-publisher login github
+#
+# Dry run by default. Pass --publish to send it for real.
 set -euo pipefail
+PUBLISH=0
+case "${1:-}" in
+  --publish) PUBLISH=1 ;;
+  "") ;;
+  *) echo "usage: $0 [--publish]" >&2; exit 2 ;;
+esac
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
 ENTRY="$HERE/registry/server.json"
@@ -32,8 +42,15 @@ print(f"stamped registry entry for thingctx=={version}")
 PY
 
 # The publisher resolves a bare server.json against the working directory, so
-# run it from the stamped copy's own directory rather than passing a path.
-echo "dry-run against the registry (login first: mcp-publisher login github)..."
-(cd "$(dirname "$STAMPED")" && mcp-publisher publish --dry-run server.json)
-echo "--- review the dry-run above; re-run without --dry-run to publish ---"
-# (cd "$(dirname "$STAMPED")" && mcp-publisher publish server.json)
+# run it from the stamped copy's own directory rather than passing a path. The
+# stamped copy is deleted when this script exits, so the publish has to happen
+# in the same run that produced it.
+if [ "$PUBLISH" -eq 1 ]; then
+  echo "publishing thingctx==$VERSION to the registry..."
+  (cd "$(dirname "$STAMPED")" && mcp-publisher publish server.json)
+  echo "published. verify: https://registry.modelcontextprotocol.io/v0/servers?search=thingctx"
+else
+  echo "dry run for thingctx==$VERSION (nothing is sent)..."
+  (cd "$(dirname "$STAMPED")" && mcp-publisher publish --dry-run server.json)
+  echo "--- dry run only. re-run as '$0 --publish' to send it. ---"
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thingctx"
-version = "0.2.1"
+version = "0.2.2"
 description = "Drive any agent against any W3C WoT Thing, over any transport. No per-integration server."
 readme = "README-pypi.md"
 requires-python = ">=3.10"

--- a/src/thingctx/__init__.py
+++ b/src/thingctx/__init__.py
@@ -132,7 +132,7 @@ from thingctx.trust import (
 )
 from thingctx.validate import TDValidationError, validate_td
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "BUILTIN_BINDINGS",


### PR DESCRIPTION
The MCP registry confirms that a listing and the package it points at share an owner by reading a marker line from the package README as published on the index:

    registry validation failed for package 0 (thingctx): PyPI package 'thingctx'
    ownership validation failed. The server name 'com.thingctx/thingctx' must
    appear as 'mcp-name: com.thingctx/thingctx' in the package README

That line has to ship in a release before the entry can be published, so this bumps to 0.2.2. Verified it survives into the built wheel's METADATA, which is what the index serves.

The publish script also gains a real `--publish` flag. It dry runs by default. The line that actually sent the entry was commented out, and the stamped copy it needs is deleted when the script exits, so uncommenting it after a run could never have worked.

`packaging/registry/PUBLISHING.md` records what the registry wants: the entry uses a domain namespace, which is proven by a TXT record on the apex, and a GitHub login only ever grants `io.github.<account>/*`.

Domain authentication is already working against the live TXT record; this is the remaining check.