### PR TITLE
fix(cli): report input errors without tracebacks

### DIFF
--- a/src/thingctx/cli.py
+++ b/src/thingctx/cli.py
@@ -60,11 +60,21 @@ def _load_td(source: str) -> dict:
     return cast(dict, json.loads(Path(source).read_text(encoding="utf-8")))
 
 
+def _load_cli_input(loader: Callable[[str], dict], source: str, description: str) -> dict:
+    """Turn expected input failures into concise command-line errors."""
+    try:
+        return loader(source)
+    except OSError as exc:
+        raise SystemExit(f"cannot read {description} {source}: {exc}") from exc
+    except ValueError as exc:
+        raise SystemExit(f"cannot parse {description} {source}: {exc}") from exc
+
+
 def _cmd_lint(args: argparse.Namespace) -> int:
     # loaded per subcommand so the CLI starts fast
     from .lint import lint_td  # noqa: PLC0415
 
-    findings = lint_td(_load_td(args.td))
+    findings = lint_td(_load_cli_input(_load_td, args.td, "Thing Description"))
     for f in findings:
         print(f"{f.severity:6} {f.target}  [{f.rule}] {f.message}", file=sys.stderr)  # noqa: T201  # CLI output
     errors = sum(1 for f in findings if f.severity == "error")
@@ -77,7 +87,7 @@ def _cmd_import_openapi(args: argparse.Namespace) -> int:
     # loaded per subcommand so the CLI starts fast
     from .openapi import from_openapi, load_spec  # noqa: PLC0415
 
-    spec = load_spec(args.spec)
+    spec = _load_cli_input(load_spec, args.spec, "OpenAPI spec")
     td = from_openapi(spec, base_url=args.base_url, id=args.id, title=args.title)
     out = json.dumps(td, indent=2) + "\n"
     if args.out:

--- a/src/thingctx/openapi.py
+++ b/src/thingctx/openapi.py
@@ -440,7 +440,10 @@ def load_spec(source: str) -> dict:
         # optional dep, kept local so the core imports without the extra
         import httpx  # noqa: PLC0415
 
-        text = httpx.get(source, follow_redirects=True, timeout=30.0).text
+        try:
+            text = httpx.get(source, follow_redirects=True, timeout=30.0).text
+        except httpx.HTTPError as exc:
+            raise OSError(str(exc)) from exc
     else:
         text = Path(source).read_text(encoding="utf-8")
     return _parse_spec(text)
@@ -458,4 +461,7 @@ def _parse_spec(text: str) -> dict:
                 "spec is not JSON and PyYAML is not installed; "
                 'install the YAML support with: pip install "thingctx[openapi]"'
             ) from exc
-        return cast(dict, yaml.safe_load(text))
+        try:
+            return cast(dict, yaml.safe_load(text))
+        except yaml.YAMLError as exc:
+            raise ValueError(str(exc)) from exc

--- a/tests/test_cli_input_errors.py
+++ b/tests/test_cli_input_errors.py
@@ -1,0 +1,82 @@
+# Copyright 2026 The thingctx Authors
+# SPDX-License-Identifier: Apache-2.0
+"""CLI input failures are concise user errors, not Python tracebacks."""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+
+import httpx
+import pytest
+
+from thingctx.cli import main
+
+
+def _exit_message(argv: list[str]) -> str:
+    with pytest.raises(SystemExit) as exc_info:
+        main(argv)
+    return str(exc_info.value)
+
+
+def test_lint_missing_file_reports_read_error(tmp_path):
+    source = tmp_path / "missing.td.json"
+
+    message = _exit_message(["lint", str(source)])
+
+    assert message.startswith(f"cannot read Thing Description {source}: ")
+    assert "No such file" in message
+
+
+def test_lint_malformed_file_reports_parse_error(tmp_path):
+    source = tmp_path / "broken.td.json"
+    source.write_text("{", encoding="utf-8")
+
+    message = _exit_message(["lint", str(source)])
+
+    assert message.startswith(f"cannot parse Thing Description {source}: ")
+
+
+def test_lint_unreachable_url_reports_read_error(monkeypatch):
+    source = "https://things.example/missing.td.json"
+
+    def fail(*args, **kwargs):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fail)
+
+    message = _exit_message(["lint", source])
+
+    assert message == f"cannot read Thing Description {source}: <urlopen error connection refused>"
+
+
+def test_import_openapi_missing_file_reports_read_error(tmp_path):
+    source = tmp_path / "missing.yaml"
+
+    message = _exit_message(["import", "openapi", str(source)])
+
+    assert message.startswith(f"cannot read OpenAPI spec {source}: ")
+    assert "No such file" in message
+
+
+def test_import_openapi_malformed_yaml_reports_parse_error(tmp_path):
+    source = tmp_path / "broken.yaml"
+    source.write_text("openapi: [", encoding="utf-8")
+
+    message = _exit_message(["import", "openapi", str(source)])
+
+    assert message.startswith(f"cannot parse OpenAPI spec {source}: ")
+
+
+def test_import_openapi_unreachable_url_reports_read_error(monkeypatch):
+    source = "https://apis.example/missing.yaml"
+
+    def fail(*args, **kwargs):
+        request = httpx.Request("GET", source)
+        raise httpx.ConnectError("connection refused", request=request)
+
+    monkeypatch.setattr(httpx, "get", fail)
+
+    message = _exit_message(["import", "openapi", source])
+
+    assert message == f"cannot read OpenAPI spec {source}: connection refused"


### PR DESCRIPTION
## Summary

- translate expected file, URL, and parse failures into concise CLI errors for `lint` and `import openapi`
- normalize HTTPX and PyYAML loader exceptions so the CLI can distinguish read failures from parse failures
- cover missing files, malformed JSON/YAML, and unreachable URLs for both commands

## Testing

- `.venv/bin/python -m pytest -q tests/test_cli_input_errors.py tests/test_openapi.py tests/test_lint.py` (58 passed)
- `.venv/bin/python -m pytest -q -m "not network"` with `mcp<2` (817 passed, 2 skipped, 4 deselected, 1 xfailed)
- repository pre-commit hooks on all changed files (passed)
- coverage reached 82.28%, above the 80% gate; one unrelated media timing test failed once and passed three immediate focused reruns

The repository current unbounded `mcp>=1.3` dev install resolves MCP 2.0, which also breaks upstream `main` CI; this PR does not change dependency policy.

Developed with AI assistance; reviewed, understood, and tested by me.

Fixes #97