### PR TITLE
fix(deps): two pins that break a clean checkout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,13 @@ http = ["httpx>=0.25"]
 mqtt = ["paho-mqtt>=2.0"]
 # Validate TDs against the official W3C WoT TD 1.1 schema.
 validate = ["jsonschema>=4.0"]
-# Expose a Thing (or a whole fleet of TDs) to any MCP client.
-mcp = ["mcp>=1.3"]
+# Expose a Thing (or a whole fleet of TDs) to any MCP client. Held below 2
+# until the bridge is ported: 2.0 renames the tool and annotation fields,
+# drops the server decorators, and moves the in-memory test helper.
+mcp = ["mcp>=1.3,<2"]
 # Serve the bridge over streamable HTTP (thingctx-mcp --http) for a hosted gateway or
 # a cloud agent runtime that only takes a remote MCP URL. starlette ships with mcp.
-mcp-http = ["mcp>=1.3", "uvicorn>=0.27"]
+mcp-http = ["mcp>=1.3,<2", "uvicorn>=0.27"]
 # Import OpenAPI specs (YAML support; JSON works without it).
 openapi = ["httpx>=0.25", "pyyaml>=6"]
 # Cloud auth: OAuth2 JWT-bearer assertions need RS256 JWT signing (pyjwt);
@@ -59,14 +61,14 @@ entra = ["azure-identity>=1.20", "pyjwt[crypto]>=2.8", "httpx>=0.27"]
 # still refuses every call until THINGCTX_FS_ROOT is set.
 filesystem = []
 # Everything.
-all = ["litellm>=1.0", "httpx>=0.27", "paho-mqtt>=2.0", "jsonschema>=4.0", "mcp>=1.3", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "av>=11", "numpy>=1.23", "pillow>=10"]
+all = ["litellm>=1.0", "httpx>=0.27", "paho-mqtt>=2.0", "jsonschema>=4.0", "mcp>=1.3,<2", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "av>=11", "numpy>=1.23", "pillow>=10"]
 # The gate tools are pinned, not floated: the CI and the pre-commit hook must
 # agree with what a contributor runs locally, or "green here, red in CI" churn
 # follows. ruff 0.14.x is where the in-function-import rule (PLC0415) is stable.
 # botocore is here only as an independent oracle for the SigV4 signer: the test
 # compares our signature against botocore's canonical one. Without it installed
 # that comparison skips, so the signing code goes unchecked.
-dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.3", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13", "diff-cover==10.4.1"]
+dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.3,<2", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13", "diff-cover==10.4.1"]
 
 [project.scripts]
 # Serve a Thing (or a whole fleet of TDs) to any MCP client.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ all = ["litellm>=1.0", "httpx>=0.27", "paho-mqtt>=2.0", "jsonschema>=4.0", "mcp>
 # botocore is here only as an independent oracle for the SigV4 signer: the test
 # compares our signature against botocore's canonical one. Without it installed
 # that comparison skips, so the signing code goes unchecked.
-dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.3,<2", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.16.0", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13", "diff-cover==10.4.1"]
+dev = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov==7.1.0", "jsonschema>=4.0", "mcp>=1.3,<2", "httpx>=0.27", "pyyaml>=6", "pyjwt[crypto]>=2.8", "azure-identity>=1.20", "paho-mqtt>=2.0", "av>=11", "numpy>=1.23", "pillow>=10", "botocore>=1.34", "ruff==0.14.4", "mypy==2.3.0", "vulture==2.16", "bandit==1.9.4", "pip-audit==2.10.1", "import-linter==2.13", "diff-cover==10.4.1"]
 
 [project.scripts]
 # Serve a Thing (or a whole fleet of TDs) to any MCP client.


### PR DESCRIPTION
Two dependency pins that make a clean checkout fail. Different symptoms, same
shape: the pin does not say what we actually support.

## 1. mcp, unbounded

CI on `main` has been red since 29 July and `pip install thingctx[mcp]` is
broken today. `mcp` 2.0.0 shipped, the requirement was `mcp>=1.3` with no upper
bound, so a clean resolve picks 2.0, which:

- drops the `@server.list_tools()` style decorators for constructor handlers
- renames `Tool.inputSchema` to `input_schema`, and the `ToolAnnotations` hints
  to snake case
- removes `Server.list_tools`
- moves `create_connected_server_and_client_session` out of `mcp.shared.memory`

Capped in the four places the pin appears, with the reason beside the extra so
it does not read as arbitrary. This is a Python dependency pin; nothing about
what a connecting client sees changes.

## 2. ruff, disagreeing with itself

The dev extra installed `ruff==0.16.0`; CI and the pre-commit hook both run
`0.14.4`. So anyone who installs the dev extra sees ten failures on a clean
checkout that CI never reports. The comment sitting directly above those pins
says they exist to stop exactly that.

Aligned the dev extra down to the version the gate runs.

## What is deliberately not here

**The mcp 2.0 port.** Real work, its own issue. It touches the elicitation
approval gate, which should not be rushed behind a red build.

**Moving ruff to 0.16.** Also real work: 0.16 adds `PLR0917`, and satisfying it
means making eight signatures keyword only, plus two trivial autofixes.

## Verified

`pytest -m "not network"`: 813 passed, 4 deselected, 1 xfailed. Full gate green
at the pinned ruff.