### PR TITLE
ci: pin remaining GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Check sign-off on PR commits

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -30,11 +30,11 @@ jobs:
         id: v
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build and push (multi-arch)
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: packaging/docker/Dockerfile
@@ -56,7 +56,7 @@ jobs:
           provenance: mode=max # SLSA provenance
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign the image (keyless, OIDC)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
               echo "::error::could not reach TestPyPI to check ${VERSION} (HTTP ${CODE})."
               exit 1 ;;
           esac
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -192,7 +192,7 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
 
   # Publish a GitHub Release for the tag after PyPI succeeds. Authored by
   # github-actions[bot] (no personal account), with auto-generated notes and


### PR DESCRIPTION
## What & why

Fixes #126.

Seven `uses:` refs were still on mutable tags — six of them in the release workflows, right next to the registry login, PyPI publish and cosign signing steps. A tag can be repointed after you review it, so those were the wrong refs to trust in the credentialed jobs. This pins each to the commit SHA its ref currently resolves to.

## SHAs — re-resolved independently

As the issue asks, I re-resolved every ref myself via `gh api repos/<action>/commits/<ref> --jq .sha` rather than trusting the listed values. They match, and `actions/checkout@v7.0.1` resolves to the same SHA already pinned elsewhere in `ci.yml` (so that line just makes the two agree):

| action | ref | SHA |
|---|---|---|
| actions/checkout | v7.0.1 | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| docker/setup-qemu-action | v4 | `96fe6ef7f33517b61c61be40b68a1882f3264fb8` |
| docker/setup-buildx-action | v4 | `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c` |
| docker/login-action | v4 | `dbcb813823bdd20940b903addbd779551569679f` |
| docker/build-push-action | v7 | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` |
| sigstore/cosign-installer | v3 | `398d4b0eeef1380460a10c8013a76f728fb906ac` |
| pypa/gh-action-pypi-publish | release/v1 | `dc37677b2e1c63e2034f94d8a5b11f265b73ba33` |

## The two trade-offs (acknowledged)

- **`pypa/gh-action-pypi-publish@release/v1` is a moving branch by design**, and it holds the PyPI publish. Pinning it means it must be bumped **deliberately** when upstream ships a fix — I understand that trade; a stale publish action is its own risk, which is why the `# release/v1` comment stays so Dependabot keeps offering the bump.
- **Every line keeps its `# vX` trailing comment** so Dependabot can still parse and bump each pin — a pin without the comment becomes a stale pin nobody notices.

## Done when

- [x] Every `uses:` in `.github/workflows/` names a SHA with a version comment — verified: `grep -rn 'uses:' .github/workflows/ | grep -vE '@[0-9a-f]{40}'` returns nothing.
- [x] YAML still parses for all three edited workflows.
- [ ] `ci.yml` still passes (CI on this PR).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
